### PR TITLE
Remove AudioDSP from ActiveAEBuffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-[![Build Status](https://travis-ci.org/xbmc/xbmc.svg?branch=master)](https://travis-ci.org/xbmc/xbmc)
+* Tarvis-CI for OS X, iOS, Linux [![Build Status](https://travis-ci.org/AchimTuran/kodi-agile.svg?branch=AudioDSP/V2/usability_core_fixes)](https://travis-ci.org/AchimTuran/kodi-agile)
+* AppVeyor for Windows [![Build status](https://ci.appveyor.com/api/projects/status/yj28c984cj2qe78q?svg=true)](https://ci.appveyor.com/project/AchimTuran/kodi-agile)
+
 [![Documentation](https://codedocs.xyz/xbmc/xbmc.svg)](https://codedocs.xyz/xbmc/xbmc/)
 
 ![Kodi logo](https://raw.githubusercontent.com/xbmc/xbmc-forum/master/xbmc/images/logo-sbs-black.png)

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.cpp
@@ -161,23 +161,17 @@ CActiveAEBufferPoolResample::CActiveAEBufferPoolResample(AEAudioFormat inputForm
     m_inputFormat.m_channelLayout.Reset();
     m_inputFormat.m_channelLayout += AE_CH_FC;
   }
-  m_resampler = NULL;
+  m_resampler = nullptr;
   m_fillPackets = false;
   m_drain = false;
   m_empty = true;
-  m_procSample = NULL;
-  m_dspSample = NULL;
-  m_dspBuffer = NULL;
+  m_procSample = nullptr;
   m_resampleRatio = 1.0;
   m_resampleQuality = quality;
   m_forceResampler = false;
   m_stereoUpmix = false;
   m_normalize = true;
-  m_useResampler = false;
-  m_useDSP = false;
-  m_bypassDSP = false;
   m_changeResampler = false;
-  m_changeDSP = false;
   m_lastSamplePts = 0;
 }
 
@@ -186,88 +180,29 @@ CActiveAEBufferPoolResample::~CActiveAEBufferPoolResample()
   Flush();
 
   delete m_resampler;
-  
-  if (m_useDSP)
-    CServiceBroker::GetADSP().DestroyDSPs(m_streamId);
-  if (m_dspBuffer)
-    delete m_dspBuffer;
 }
 
-void CActiveAEBufferPoolResample::SetExtraData(int profile, enum AVMatrixEncoding matrix_encoding, enum AVAudioServiceType audio_service_type)
-{
-  m_Profile = profile;
-  m_MatrixEncoding = matrix_encoding;
-  m_AudioServiceType = audio_service_type;
-
-  if (m_useDSP)
-    ChangeAudioDSP();
-}
-
-bool CActiveAEBufferPoolResample::Create(unsigned int totaltime, bool remap, bool upmix, bool normalize, bool useDSP)
+bool CActiveAEBufferPoolResample::Create(unsigned int totaltime, bool remap, bool upmix, bool normalize)
 {
   CActiveAEBufferPool::Create(totaltime);
 
   m_remap = remap;
   m_stereoUpmix = upmix;
-  m_useResampler = m_changeResampler;                                       /* if m_changeResampler is true on Create, system require the usage of resampler */
-
-  /*
-   * On first used resample class, DSP signal processing becomes performed.
-   * For the signal processing the input data for CActiveAEResample must be
-   * modified to have a full supported audio stream with all available
-   * channels, for this reason also some in resample used functions must be
-   * disabled.
-   *
-   * The reason to perform this before CActiveAEResample is to have a unmodified
-   * stream with the basic data to have best quality like for surround upmix.
-   *
-   * The value m_streamId and address pointer m_processor are passed a pointers
-   * to CServiceBroker::GetADSP().CreateDSPs and set from it.
-   */
-  if ((useDSP || m_changeDSP) && !m_bypassDSP)
-  {
-    m_dspFormat = m_inputFormat;
-    m_useDSP = CServiceBroker::GetADSP().CreateDSPs(m_streamId, m_processor, m_dspFormat, m_format, upmix, m_resampleQuality, m_MatrixEncoding, m_AudioServiceType, m_Profile);
-    if (m_useDSP)
-    {
-
-      m_inputFormat.m_channelLayout = m_processor->GetChannelLayout();    /* Overide input format with DSP's supported format */
-      m_inputFormat.m_sampleRate    = m_processor->GetOutputSamplerate(); /* Overide input format with DSP's generated samplerate */
-      m_inputFormat.m_dataFormat    = m_processor->GetDataFormat();       /* Overide input format with DSP's processed data format, normally it is float */
-      m_inputFormat.m_frames        = m_processor->GetOutputFrames();
-      m_forceResampler              = true;                               /* Force load of ffmpeg resampler, required to detect exact input and output channel alignment pointers */
-      if (m_processor->GetChannelLayout().Count() > 2)                    /* Disable upmix for CActiveAEResample if DSP layout > 2.0, becomes perfomed by DSP */
-        upmix = false;
-
-      m_dspBuffer = new CActiveAEBufferPool(m_inputFormat);               /* Get dsp processing buffer class, based on dsp output format */
-      m_dspBuffer->Create(totaltime);
-    }
-  }
-  m_changeDSP  = false;
 
   m_normalize = true;
   if ((m_format.m_channelLayout.Count() < m_inputFormat.m_channelLayout.Count() && !normalize))
     m_normalize = false;
 
-  /*
-   * Compare the input format with output, if there is one different format, perform the
-   * kodi based resample processing.
-   *
-   * The input format can be become modified if addon dsp processing is enabled. For this
-   * reason somethings are no more required for it. As example, if resampling is performed
-   * by the addons it is no more required here, also the channel layout can be modified
-   * from addons. The output data format from dsp is always float and if something other
-   * is required here, the CActiveAEResample must change it.
-   */
   if (m_inputFormat.m_channelLayout != m_format.m_channelLayout ||
       m_inputFormat.m_sampleRate != m_format.m_sampleRate ||
       m_inputFormat.m_dataFormat != m_format.m_dataFormat ||
-      m_forceResampler)
-    m_useResampler = true;
-
-  if (m_useResampler || m_changeResampler)
+      m_changeResampler)
   {
-    m_resampler = CAEResampleFactory::Create();
+    if (!m_resampler)
+    {
+      m_resampler = CAEResampleFactory::Create();
+    }
+
     m_resampler->Init(CAEUtil::GetAVChannelLayout(m_format.m_channelLayout),
                                 m_format.m_channelLayout.Count(),
                                 m_format.m_sampleRate,
@@ -285,10 +220,9 @@ bool CActiveAEBufferPoolResample::Create(unsigned int totaltime, bool remap, boo
                                 remap ? &m_format.m_channelLayout : NULL,
                                 m_resampleQuality,
                                 m_forceResampler);
+
+    m_changeResampler = false;
   }
-
-  m_changeResampler = false;
-
   return true;
 }
 
@@ -299,10 +233,6 @@ void CActiveAEBufferPoolResample::ChangeResampler()
     delete m_resampler;
     m_resampler = NULL;
   }
-
-  bool upmix = m_stereoUpmix;
-  if (m_useDSP && m_processor && m_processor->GetChannelLayout().Count() > 2)
-    upmix = false;
 
   m_resampler = CAEResampleFactory::Create();
   m_resampler->Init(CAEUtil::GetAVChannelLayout(m_format.m_channelLayout),
@@ -317,63 +247,13 @@ void CActiveAEBufferPoolResample::ChangeResampler()
                                 CAEUtil::GetAVSampleFormat(m_inputFormat.m_dataFormat),
                                 CAEUtil::DataFormatToUsedBits(m_inputFormat.m_dataFormat),
                                 CAEUtil::DataFormatToDitherBits(m_inputFormat.m_dataFormat),
-                                upmix,
+                                m_stereoUpmix,
                                 m_normalize,
                                 m_remap ? &m_format.m_channelLayout : NULL,
                                 m_resampleQuality,
                                 m_forceResampler);
 
   m_changeResampler = false;
-}
-
-void CActiveAEBufferPoolResample::ChangeAudioDSP()
-{
-  /* if dsp was enabled before reset input format, also used for failed dsp creation */
-  bool wasActive = false;
-  if (m_useDSP && m_processor != NULL)
-  {
-    m_inputFormat = m_processor->GetInputFormat();
-    wasActive = true;
-  }
-
-  m_useDSP = CServiceBroker::GetADSP().CreateDSPs(m_streamId, m_processor, m_dspFormat, m_format, m_stereoUpmix, m_resampleQuality, m_MatrixEncoding, m_AudioServiceType, m_Profile, wasActive);
-  if (m_useDSP)
-  {
-    m_inputFormat.m_channelLayout = m_processor->GetChannelLayout();    /* Overide input format with DSP's supported format */
-    m_inputFormat.m_sampleRate    = m_processor->GetOutputSamplerate(); /* Overide input format with DSP's generated samplerate */
-    m_inputFormat.m_dataFormat    = m_processor->GetDataFormat();       /* Overide input format with DSP's processed data format, normally it is float */
-    m_inputFormat.m_frames        = m_processor->GetOutputFrames();
-    m_changeResampler             = true;                               /* Force load of ffmpeg resampler, required to detect exact input and output channel alignment pointers */
-  }
-  else if (wasActive)
-  {
-    /*
-     * Check now after the dsp processing becomes disabled, that the resampler is still
-     * required, if not unload it also.
-     */
-    if (m_inputFormat.m_channelLayout == m_format.m_channelLayout &&
-        m_inputFormat.m_sampleRate == m_format.m_sampleRate &&
-        m_inputFormat.m_dataFormat == m_format.m_dataFormat &&
-        !m_useResampler)
-    {
-      delete m_resampler;
-      m_resampler = NULL;
-      delete m_dspBuffer;
-      m_dspBuffer = NULL;
-      m_changeResampler = false;
-    }
-    else
-      m_changeResampler = true;
-
-    m_useDSP = false;
-    CServiceBroker::GetADSP().DestroyDSPs(m_streamId);
-  }
-  else
-  {
-    m_useDSP = false;
-  }
-
-  m_changeDSP = false;
 }
 
 bool CActiveAEBufferPoolResample::ResampleBuffers(int64_t timestamp)
@@ -383,10 +263,8 @@ bool CActiveAEBufferPoolResample::ResampleBuffers(int64_t timestamp)
 
   if (!m_resampler)
   {
-    if (m_changeDSP || m_changeResampler)
+    if (m_changeResampler)
     {
-      if (m_changeDSP)
-        ChangeAudioDSP();
       if (m_changeResampler)
         ChangeResampler();
       return true;
@@ -418,43 +296,20 @@ bool CActiveAEBufferPoolResample::ResampleBuffers(int64_t timestamp)
 
     bool hasInput = !m_inputSamples.empty();
 
-    if (hasInput || skipInput || m_drain || m_changeResampler || m_changeDSP)
+    if (hasInput || skipInput || m_drain || m_changeResampler)
     {
       if (!m_procSample)
       {
         m_procSample = GetFreeBuffer();
       }
 
-      if (hasInput && !skipInput && !m_changeResampler && !m_changeDSP)
+      if (hasInput && !skipInput && !m_changeResampler)
       {
         in = m_inputSamples.front();
         m_inputSamples.pop_front();
       }
       else
         in = NULL;
-
-      /*
-       * DSP need always a available input packet! To pass it step by step
-       * over all enabled addons and processing segments.
-       */
-      if (m_useDSP && in)
-      {
-        if (!m_dspSample)
-          m_dspSample = m_dspBuffer->GetFreeBuffer();
-
-        if (m_dspSample && m_processor->Process(in, m_dspSample))
-        {
-          m_dspSample->timestamp = in->timestamp;
-          in->Return();
-          in = m_dspSample;
-          m_dspSample = NULL;
-        }
-        else
-        {
-          in->Return();
-          in = NULL;
-        }
-      }
 
       int start = m_procSample->pkt->nb_samples *
                   m_procSample->pkt->bytes_per_sample *
@@ -506,7 +361,7 @@ bool CActiveAEBufferPoolResample::ResampleBuffers(int64_t timestamp)
       m_procSample->pkt_start_offset = m_procSample->pkt->nb_samples;
       m_procSample->timestamp = m_lastSamplePts - bufferedSamples * 1000 / m_format.m_sampleRate;
 
-      if ((m_drain || m_changeResampler || m_changeDSP) && m_empty)
+      if ((m_drain || m_changeResampler) && m_empty)
       {
         if (m_fillPackets && m_procSample->pkt->nb_samples != 0)
         {
@@ -531,8 +386,6 @@ bool CActiveAEBufferPoolResample::ResampleBuffers(int64_t timestamp)
           m_outputSamples.push_back(m_procSample);
 
         m_procSample = NULL;
-        if (m_changeDSP)
-          ChangeAudioDSP();
         if (m_changeResampler)
           ChangeResampler();
       }
@@ -550,37 +403,20 @@ bool CActiveAEBufferPoolResample::ResampleBuffers(int64_t timestamp)
   return busy;
 }
 
-void CActiveAEBufferPoolResample::ConfigureResampler(bool normalizelevels, bool dspenabled, bool stereoupmix, AEQuality quality)
+void CActiveAEBufferPoolResample::ConfigureResampler(bool normalizelevels, bool stereoupmix, AEQuality quality)
 {
   bool normalize = true;
-  if ((m_format.m_channelLayout.Count() < m_inputFormat.m_channelLayout.Count()) &&
-      normalizelevels)
+  if ((m_format.m_channelLayout.Count() < m_inputFormat.m_channelLayout.Count()) && normalizelevels)
+  {
     normalize = false;
+  }
 
-  /* Disable upmix if DSP layout > 2.0, becomes perfomed by DSP */
-  bool ignoreUpmix = false;
-  if (dspenabled && m_useDSP && m_processor->GetChannelLayout().Count() > 2)
-    ignoreUpmix = true;
-
-  if (m_useResampler &&
-      ((m_resampleQuality != quality) ||
-       ((m_stereoUpmix != stereoupmix) && !ignoreUpmix) ||
-       (m_normalize != normalize)))
+  if (m_normalize != normalize || m_resampleQuality != quality)
   {
     m_changeResampler = true;
   }
 
-  if (m_useDSP != dspenabled ||
-      (m_useDSP &&
-      ((m_resampleQuality != quality) ||
-      (m_stereoUpmix != stereoupmix))))
-  {
-    m_changeDSP = true;
-  }
-
-  m_useDSP = dspenabled;
   m_resampleQuality = quality;
-  m_stereoUpmix = stereoupmix;
   m_normalize = normalize;
 }
 
@@ -591,8 +427,6 @@ float CActiveAEBufferPoolResample::GetDelay()
 
   if (m_procSample)
     delay += (float)m_procSample->pkt->nb_samples / m_procSample->pkt->config.sample_rate;
-  if (m_dspSample)
-    delay += (float)m_dspSample->pkt->nb_samples / m_dspSample->pkt->config.sample_rate;
 
   for(itBuf=m_inputSamples.begin(); itBuf!=m_inputSamples.end(); ++itBuf)
   {
@@ -610,11 +444,6 @@ float CActiveAEBufferPoolResample::GetDelay()
     delay += (float)samples / m_format.m_sampleRate;
   }
 
-  if (m_useDSP)
-  {
-    delay += m_processor->GetDelay();
-  }
-
   return delay;
 }
 
@@ -624,11 +453,6 @@ void CActiveAEBufferPoolResample::Flush()
   {
     m_procSample->Return();
     m_procSample = NULL;
-  }
-  if (m_dspSample)
-  {
-    m_dspSample->Return();
-    m_dspSample = NULL;
   }
   while (!m_inputSamples.empty())
   {
@@ -674,11 +498,6 @@ void CActiveAEBufferPoolResample::ForceResampler(bool force)
   m_forceResampler = force;
 }
 
-void CActiveAEBufferPoolResample::SetDSPConfig(bool usedsp, bool bypassdsp)
-{
-  m_useDSP = usedsp;
-  m_bypassDSP = bypassdsp;
-}
 
 // ----------------------------------------------------------------------------------
 // Atempo

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEBuffer.h
@@ -97,10 +97,9 @@ class CActiveAEBufferPoolResample : public CActiveAEBufferPool
 public:
   CActiveAEBufferPoolResample(AEAudioFormat inputFormat, AEAudioFormat outputFormat, AEQuality quality);
   virtual ~CActiveAEBufferPoolResample();
-  bool Create(unsigned int totaltime, bool remap, bool upmix, bool normalize = true, bool useDSP = false);
-  void SetExtraData(int profile, enum AVMatrixEncoding matrix_encoding, enum AVAudioServiceType audio_service_type);
+  bool Create(unsigned int totaltime, bool remap, bool upmix, bool normalize = true);
   bool ResampleBuffers(int64_t timestamp = 0);
-  void ConfigureResampler(bool normalizelevels, bool dspenabled, bool stereoupmix, AEQuality quality);
+  void ConfigureResampler(bool normalizelevels, bool stereoupmix, AEQuality quality);
   float GetDelay();
   void Flush();
   void SetDrain(bool drain);
@@ -109,7 +108,6 @@ public:
   void FillBuffer();
   bool DoesNormalize();
   void ForceResampler(bool force);
-  void SetDSPConfig(bool usedsp, bool bypassdsp);
   AEAudioFormat m_inputFormat;
   std::deque<CSampleBuffer*> m_inputSamples;
   std::deque<CSampleBuffer*> m_outputSamples;
@@ -120,33 +118,17 @@ protected:
   uint8_t *m_planes[16];
   bool m_empty;
   bool m_drain;
-  int m_Profile;
   int64_t m_lastSamplePts;
   bool m_remap;
   CSampleBuffer *m_procSample;
   IAEResample *m_resampler;
   double m_resampleRatio;
   bool m_fillPackets;
-  bool m_stereoUpmix;
   bool m_normalize;
-  bool m_useResampler;
   bool m_changeResampler;
   bool m_forceResampler;
   AEQuality m_resampleQuality;
-
-  // ADSP
-  // TODO move away from resample buffers
-  void ChangeAudioDSP();
-  unsigned int m_streamId;
-  enum AVMatrixEncoding m_MatrixEncoding;
-  enum AVAudioServiceType m_AudioServiceType;
-  CSampleBuffer *m_dspSample;
-  AEAudioFormat m_dspFormat;
-  CActiveAEDSPProcessPtr m_processor;
-  CActiveAEBufferPool *m_dspBuffer;
-  bool m_changeDSP;
-  bool m_useDSP;
-  bool m_bypassDSP;
+  bool m_stereoUpmix;
 };
 
 class CActiveAEFilter;

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/ActiveAEStream.cpp
@@ -603,7 +603,7 @@ bool CActiveAEStreamBuffers::HasInputLevel(int level)
 
 bool CActiveAEStreamBuffers::Create(unsigned int totaltime, bool remap, bool upmix, bool normalize, bool useDSP)
 {
-  if (!m_resampleBuffers->Create(totaltime, remap, upmix, normalize, useDSP))
+  if (!m_resampleBuffers->Create(totaltime, remap, upmix, normalize))
     return false;
 
   if (!m_atempoBuffers->Create(totaltime))
@@ -614,7 +614,7 @@ bool CActiveAEStreamBuffers::Create(unsigned int totaltime, bool remap, bool upm
 
 void CActiveAEStreamBuffers::SetExtraData(int profile, enum AVMatrixEncoding matrix_encoding, enum AVAudioServiceType audio_service_type)
 {
-  m_resampleBuffers->SetExtraData(profile, matrix_encoding, audio_service_type);
+  /*! @todo Implement set dsp config with new AudioDSP buffer implementation */
 }
 
 bool CActiveAEStreamBuffers::ProcessBuffers()
@@ -655,7 +655,7 @@ bool CActiveAEStreamBuffers::ProcessBuffers()
 
 void CActiveAEStreamBuffers::ConfigureResampler(bool normalizelevels, bool dspenabled, bool stereoupmix, AEQuality quality)
 {
-  m_resampleBuffers->ConfigureResampler(normalizelevels, dspenabled, stereoupmix, quality);
+  m_resampleBuffers->ConfigureResampler(normalizelevels, stereoupmix, quality);
 }
 
 float CActiveAEStreamBuffers::GetDelay()
@@ -753,7 +753,7 @@ void CActiveAEStreamBuffers::ForceResampler(bool force)
 
 void CActiveAEStreamBuffers::SetDSPConfig(bool usedsp, bool bypassdsp)
 {
-  m_resampleBuffers->SetDSPConfig(usedsp, bypassdsp);
+ /*! @todo Implement set dsp config with new AudioDSP buffer implementation */
 }
 
 CActiveAEBufferPool* CActiveAEStreamBuffers::GetResampleBuffers()

--- a/xbmc/cores/AudioEngine/Utils/AEChannelInfo.cpp
+++ b/xbmc/cores/AudioEngine/Utils/AEChannelInfo.cpp
@@ -252,7 +252,7 @@ CAEChannelInfo::operator std::string() const
   for (unsigned int i = 0; i < m_channelCount - 1; ++i)
   {
     s.append(GetChName(m_channels[i]));
-    s.append(",");
+    s.append(", ");
   }
   s.append(GetChName(m_channels[m_channelCount-1]));
 


### PR DESCRIPTION
@FernetMenta @fritsch @AlwinEsch 
These commits remove AudioDSP from ActiveAEBuffer class. After this is merged I will start to PR my AudioDSP fixes.