### PR TITLE
[addon] remove not needed 'GetInfo(...)' call for ScreenSaver

### DIFF
--- a/xbmc/addons/ScreenSaver.cpp
+++ b/xbmc/addons/ScreenSaver.cpp
@@ -91,12 +91,6 @@ void CScreenSaver::Render()
   if (Initialized()) m_pStruct->Render();
 }
 
-void CScreenSaver::GetInfo(SCR_INFO *info)
-{
-  // get info from screensaver
-  if (Initialized()) m_pStruct->GetInfo(info);
-}
-
 void CScreenSaver::Destroy()
 {
 #ifdef HAS_PYTHON

--- a/xbmc/addons/ScreenSaver.h
+++ b/xbmc/addons/ScreenSaver.h
@@ -40,7 +40,6 @@ public:
   bool CreateScreenSaver();
   void Start();
   void Render();
-  void GetInfo(SCR_INFO *info);
   void Destroy();
 };
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_scr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_scr_dll.h
@@ -29,14 +29,12 @@ extern "C"
   // Functions that your visualisation must implement
   void Start();
   void Render();
-  void GetInfo(SCR_INFO* pInfo);
 
   // function to export the above structure to XBMC
   void __declspec(dllexport) get_addon(struct ScreenSaver* pScr)
   {
     pScr->Start = Start;
     pScr->Render = Render;
-    pScr->GetInfo = GetInfo;
   };
 };
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_scr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_scr_types.h
@@ -22,11 +22,6 @@
 
 extern "C"
 {
-  struct SCR_INFO
-  {
-    int dummy;
-  };
-
   struct SCR_PROPS
   {
     void *device;
@@ -44,7 +39,6 @@ extern "C"
   {
     void (__cdecl* Start) ();
     void (__cdecl* Render) ();
-    void (__cdecl* GetInfo)(SCR_INFO *info);
   };
 }
 


### PR DESCRIPTION
Remove a never used call for screensaver's

The `GetInfo(...)` is no more required on them anymore.