### PR TITLE
[cmake] fix compile with add of missing parts

### DIFF
--- a/project/cmake/treedata/common/subdirs.txt
+++ b/project/cmake/treedata/common/subdirs.txt
@@ -18,6 +18,10 @@ xbmc/input                                      input
 xbmc/input/joysticks                            input/joysticks
 xbmc/input/joysticks/dialogs                    input/joysticks/dialogs
 xbmc/input/joysticks/generic                    input/joysticks/generic
+xbmc/input/keyboard                             input/keyboard
+xbmc/input/keyboard/generic                     input/keyboard/generic
+xbmc/input/mouse                                input/mouse
+xbmc/input/mouse/generic                        input/mouse/generic
 xbmc/listproviders                              listproviders
 xbmc/media                                      media
 xbmc/messaging                                  messaging


### PR DESCRIPTION
This fix the following linker error:

```
build/input/input.a(InputManager.cpp.o):InputManager.cpp:function CInputManager::RegisterMouseHandler[abi:cxx11](MOUSE::IMouseInputHandler*): error: undefined reference to 'MOUSE::CMouseInputHandling::CMouseInputHandling(MOUSE::IMouseInputHandler*, MOUSE::IMouseButtonMap*)'
build/input/input.a(InputManager.cpp.o):InputManager.cpp:function CInputManager::CInputManager(): error: undefined reference to 'vtable for MOUSE::CMouseWindowingButtonMap'
/usr/bin/ld.gold: the vtable symbol may be undefined because the class is missing its key function
build/input/input.a(InputManager.cpp.o):InputManager.cpp:function CInputManager::CInputManager(): error: undefined reference to 'KEYBOARD::CKeyboardEasterEgg::CKeyboardEasterEgg()'
build/peripherals/devices/peripherals_devices.a(PeripheralJoystickEmulation.cpp.o):PeripheralJoystickEmulation.cpp:function PERIPHERALS::CPeripheralJoystickEmulation::RegisterJoystickDriverHandler(JOYSTICK::IDriverHandler*, bool): error: undefined reference to 'KEYBOARD::CJoystickEmulation::CJoystickEmulation(JOYSTICK::IDriverHandler*)'
collect2: error: ld returned 1 exit status
CMakeFiles/kodi.dir/build.make:411: die Regel für Ziel „kodi.bin“ scheiterte
make[2]: *** [kodi.bin] Fehler 1
CMakeFiles/Makefile2:1017: die Regel für Ziel „CMakeFiles/kodi.dir/all“ scheiterte
make[1]: *** [CMakeFiles/kodi.dir/all] Fehler 2
Makefile:138: die Regel für Ziel „all“ scheiterte
make: *** [all] Fehler 2
```

@FernetMenta compile and test was OK here, but not complete sure if maybe something else is missing.