### PR TITLE
[peripheral] bring back the use of namespace ADDON to header

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_peripheral.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_peripheral.h
@@ -47,6 +47,9 @@ typedef struct CB_PeripheralLib
 } /* namespace KodiAPI */
 } /* extern "C" */
 
+namespace ADDON
+{
+
 class CHelper_libKODI_peripheral
 {
 public:
@@ -118,3 +121,5 @@ private:
   AddonCB* m_Handle;
   KodiAPI::Peripheral::CB_PeripheralLib* m_Callbacks;
 };
+
+} /* namespace ADDON */


### PR DESCRIPTION
Was removed on rework, but now put back to prevent compile errors without
rework as long as possible on add-ons.