### PR TITLE
[addons] remove use of try, catch

### DIFF
--- a/xbmc/addons/InputStream.cpp
+++ b/xbmc/addons/InputStream.cpp
@@ -110,14 +110,7 @@ void CInputStream::UpdateConfig()
 
   if (status != ADDON_STATUS_PERMANENT_FAILURE)
   {
-    try
-    {
-      pathList = m_pStruct->GetPathList();
-    }
-    catch (std::exception &e)
-    {
-      CLog::Log(LOGERROR, "CInputStream::Supports - could not get a list of paths. Reason: %s", e.what());
-    }
+    pathList = m_pStruct->GetPathList();
     Destroy();
   }
 
@@ -235,18 +228,9 @@ bool CInputStream::Open(CFileItem &fileitem)
   props.m_libFolder = libFolder.c_str();
   props.m_profileFolder = profileFolder.c_str();
 
-  bool ret = false;
-  try
-  {
-    ret = m_pStruct->Open(props);
-    if (ret)
-      m_caps = m_pStruct->GetCapabilities();
-  }
-  catch (std::exception &e)
-  {
-    CLog::Log(LOGERROR, "CInputStream::Open - could not open stream. Reason: %s", e.what());
-    return false;
-  }
+  bool ret = m_pStruct->Open(props);
+  if (ret)
+    m_caps = m_pStruct->GetCapabilities();
 
   UpdateStreams();
   return ret;
@@ -254,14 +238,7 @@ bool CInputStream::Open(CFileItem &fileitem)
 
 void CInputStream::Close()
 {
-  try
-  {
-    m_pStruct->Close();
-  }
-  catch (std::exception &e)
-  {
-    CLog::Log(LOGERROR, "CInputStream::Close - could not close stream. Reason: %s", e.what());
-  }
+  m_pStruct->Close();
 
   if (!m_bIsChild)
   {
@@ -275,45 +252,18 @@ void CInputStream::Close()
 // IDisplayTime
 int CInputStream::GetTotalTime()
 {
-  int ret = 0;
-  try
-  {
-    ret = m_pStruct->GetTotalTime();
-  }
-  catch (std::exception &e)
-  {
-    CLog::Log(LOGERROR, "CInputStream::GetTotalTime - error. Reason: %s", e.what());
-  }
-  return ret;
+  return m_pStruct->GetTotalTime();
 }
 
 int CInputStream::GetTime()
 {
-  int ret = 0;
-  try
-  {
-    ret = m_pStruct->GetTime();
-  }
-  catch (std::exception &e)
-  {
-    CLog::Log(LOGERROR, "CInputStream::GetTime - error. Reason: %s", e.what());
-  }
-  return ret;
+  return m_pStruct->GetTime();
 }
 
 // IPosTime
 bool CInputStream::PosTime(int ms)
 {
-  bool ret = false;
-  try
-  {
-    ret = m_pStruct->PosTime(ms);
-  }
-  catch (std::exception &e)
-  {
-    CLog::Log(LOGERROR, "CInputStream::PosTime - error. Reason: %s", e.what());
-  }
-  return ret;
+  return m_pStruct->PosTime(ms);
 }
 
 // IDemux
@@ -321,18 +271,7 @@ void CInputStream::UpdateStreams()
 {
   DisposeStreams();
 
-  INPUTSTREAM_IDS streamIDs;
-  try
-  {
-    streamIDs = m_pStruct->GetStreamIds();
-  }
-  catch (std::exception &e)
-  {
-    DisposeStreams();
-    CLog::Log(LOGERROR, "CInputStream::UpdateStreams - error GetStreamIds. Reason: %s", e.what());
-    return;
-  }
-
+  INPUTSTREAM_IDS streamIDs = m_pStruct->GetStreamIds();
   if (streamIDs.m_streamCount > INPUTSTREAM_IDS::MAX_STREAM_COUNT)
   {
     DisposeStreams();
@@ -341,18 +280,7 @@ void CInputStream::UpdateStreams()
 
   for (unsigned int i=0; i<streamIDs.m_streamCount; i++)
   {
-    INPUTSTREAM_INFO stream;
-    try
-    {
-      stream = m_pStruct->GetStream(streamIDs.m_streamIds[i]);
-    }
-    catch (std::exception &e)
-    {
-      DisposeStreams();
-      CLog::Log(LOGERROR, "CInputStream::GetTotalTime - error GetStream. Reason: %s", e.what());
-      return;
-    }
-
+    INPUTSTREAM_INFO stream = m_pStruct->GetStream(streamIDs.m_streamIds[i]);
     if (stream.m_streamType == INPUTSTREAM_INFO::TYPE_NONE)
       continue;
 
@@ -455,28 +383,12 @@ void CInputStream::EnableStream(int iStreamId, bool enable)
   if (it == m_streams.end())
     return;
 
-  try
-  {
-    m_pStruct->EnableStream(it->second->uniqueId, enable);
-  }
-  catch (std::exception &e)
-  {
-    CLog::Log(LOGERROR, "CInputStream::EnableStream - error. Reason: %s", e.what());
-  }
+  m_pStruct->EnableStream(it->second->uniqueId, enable);
 }
 
 DemuxPacket* CInputStream::ReadDemux()
 {
-  DemuxPacket* pPacket = nullptr;
-  try
-  {
-    pPacket = m_pStruct->DemuxRead();
-  }
-  catch (std::exception &e)
-  {
-    CLog::Log(LOGERROR, "CInputStream::ReadDemux - error. Reason: %s", e.what());
-    return nullptr;
-  }
+  DemuxPacket* pPacket = m_pStruct->DemuxRead();
 
   if (!pPacket)
   {
@@ -496,146 +408,57 @@ DemuxPacket* CInputStream::ReadDemux()
 
 bool CInputStream::SeekTime(double time, bool backward, double* startpts)
 {
-  bool ret = false;
-  try
-  {
-    ret = m_pStruct->DemuxSeekTime(time, backward, startpts);
-  }
-  catch (std::exception &e)
-  {
-    CLog::Log(LOGERROR, "CInputStream::SeekTime - error. Reason: %s", e.what());
-  }
-  return ret;
+  return m_pStruct->DemuxSeekTime(time, backward, startpts);
 }
 
 void CInputStream::AbortDemux()
 {
-  try
-  {
-    m_pStruct->DemuxAbort();
-  }
-  catch (std::exception &e)
-  {
-    CLog::Log(LOGERROR, "CInputStream::AbortDemux - error. Reason: %s", e.what());
-  }
+  m_pStruct->DemuxAbort();
 }
 
 void CInputStream::FlushDemux()
 {
-  try
-  {
-    m_pStruct->DemuxFlush();
-  }
-  catch (std::exception &e)
-  {
-    CLog::Log(LOGERROR, "CInputStream::FlushDemux - error. Reason: %s", e.what());
-  }
+  m_pStruct->DemuxFlush();
 }
 
 void CInputStream::SetSpeed(int iSpeed)
 {
-  try
-  {
-    m_pStruct->DemuxSetSpeed(iSpeed);
-  }
-  catch (std::exception &e)
-  {
-    CLog::Log(LOGERROR, "CInputStream::SetSpeed - error. Reason: %s", e.what());
-  }
+  m_pStruct->DemuxSetSpeed(iSpeed);
 }
 
 int CInputStream::ReadStream(uint8_t* buf, unsigned int size)
 {
-  int ret = -1;
-  try
-  {
-    ret = m_pStruct->ReadStream(buf, size);
-  }
-  catch (std::exception &e)
-  {
-    CLog::Log(LOGERROR, "CInputStream::ReadStream - error. Reason: %s", e.what());
-  }
-  return ret;
+  return m_pStruct->ReadStream(buf, size);
 }
 
 int64_t CInputStream::SeekStream(int64_t offset, int whence)
 {
-  int64_t ret = -1;
-  try
-  {
-    ret = m_pStruct->SeekStream(offset, whence);
-  }
-  catch (std::exception &e)
-  {
-    CLog::Log(LOGERROR, "CInputStream::SeekStream - error. Reason: %s", e.what());
-  }
-  return ret;
+  return m_pStruct->SeekStream(offset, whence);
 }
 
 int64_t CInputStream::PositionStream()
 {
-  int64_t ret = -1;
-  try
-  {
-    ret = m_pStruct->PositionStream();
-  }
-  catch (std::exception &e)
-  {
-    CLog::Log(LOGERROR, "CInputStream::PositionStream - error. Reason: %s", e.what());
-  }
-  return ret;
+  return m_pStruct->PositionStream();
 }
 
 int64_t CInputStream::LengthStream()
 {
-  int64_t ret = -1;
-  try
-  {
-    ret = m_pStruct->LengthStream();
-  }
-  catch (std::exception &e)
-  {
-    CLog::Log(LOGERROR, "CInputStream::LengthStream - error. Reason: %s", e.what());
-  }
-  return ret;
+  return m_pStruct->LengthStream();
 }
 
 void CInputStream::PauseStream(double time)
 {
-  try
-  {
-    m_pStruct->PauseStream(time);
-  }
-  catch (std::exception &e)
-  {
-    CLog::Log(LOGERROR, "CInputStream::PauseStream - error. Reason: %s", e.what());
-  }
+  m_pStruct->PauseStream(time);
 }
 
 bool CInputStream::IsRealTimeStream()
 {
-  bool ret = false;
-  try
-  {
-    ret = m_pStruct->IsRealTimeStream();
-  }
-  catch (std::exception &e)
-  {
-    CLog::Log(LOGERROR, "CInputStream::IsRealTimeStream - error. Reason: %s", e.what());
-  }
-  return ret;
+  return m_pStruct->IsRealTimeStream();
 }
 
 void CInputStream::SetVideoResolution(int width, int height)
 {
-  try
-  {
-    m_pStruct->SetVideoResolution(width, height);
-  }
-  catch (std::exception &e)
-  {
-    CLog::Log(LOGERROR, "CInputStream::SetVideoResolution - error. Reason: %s", e.what());
-  }
+  m_pStruct->SetVideoResolution(width, height);
 }
 
 } /*namespace ADDON*/

--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -708,7 +708,6 @@ namespace PVR
     bool CanPlayChannel(const CPVRChannelPtr &channel) const;
 
     bool LogError(const PVR_ERROR error, const char *strMethod) const;
-    void LogException(const std::exception &e, const char *strFunctionName) const;
 
     bool                   m_bReadyToUse;          /*!< true if this add-on is initialised (ADDON_Create returned true), false otherwise */
     PVR_CONNECTION_STATE   m_connectionState;      /*!< the backend connection state */

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSPAddon.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSPAddon.cpp
@@ -23,7 +23,6 @@
 #include "ActiveAEDSPAddon.h"
 #include "ActiveAEDSP.h"
 #include "addons/kodi-addon-dev-kit/include/kodi/libKODI_guilib.h"
-#include "commons/Exception.h"
 #include "settings/AdvancedSettings.h"
 #include "settings/Settings.h"
 #include "utils/log.h"
@@ -124,17 +123,8 @@ ADDON_STATUS CActiveAEDSPAddon::Create(int iClientId)
   /* initialise the add-on */
   bool bReadyToUse(false);
   CLog::Log(LOGDEBUG, "ActiveAE DSP - %s - creating audio dsp add-on instance '%s'", __FUNCTION__, Name().c_str());
-  try
-  {
-    if ((status = CAddonDll<DllAudioDSP, AudioDSP, AE_DSP_PROPERTIES>::Create()) == ADDON_STATUS_OK)
-      bReadyToUse = GetAddonProperties();
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
+  if ((status = CAddonDll<DllAudioDSP, AudioDSP, AE_DSP_PROPERTIES>::Create()) == ADDON_STATUS_OK)
+    bReadyToUse = GetAddonProperties();
 
   m_bReadyToUse = bReadyToUse;
 
@@ -143,17 +133,7 @@ ADDON_STATUS CActiveAEDSPAddon::Create(int iClientId)
 
 bool CActiveAEDSPAddon::DllLoaded(void) const
 {
-  try
-  {
-    return CAddonDll<DllAudioDSP, AudioDSP, AE_DSP_PROPERTIES>::DllLoaded();
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-  }
-
-  return false;
+  return CAddonDll<DllAudioDSP, AudioDSP, AE_DSP_PROPERTIES>::DllLoaded();
 }
 
 void CActiveAEDSPAddon::Destroy(void)
@@ -166,16 +146,7 @@ void CActiveAEDSPAddon::Destroy(void)
   CLog::Log(LOGDEBUG, "ActiveAE DSP - %s - destroying audio dsp add-on '%s'", __FUNCTION__, GetFriendlyName().c_str());
 
   /* destroy the add-on */
-  try
-  {
-    CAddonDll<DllAudioDSP, AudioDSP, AE_DSP_PROPERTIES>::Destroy();
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
+  CAddonDll<DllAudioDSP, AudioDSP, AE_DSP_PROPERTIES>::Destroy();
 
   /* reset all properties to defaults */
   ResetProperties();
@@ -223,16 +194,7 @@ bool CActiveAEDSPAddon::CheckAPIVersion(void)
 {
   /* check the API version */
   AddonVersion minVersion = AddonVersion(KODI_AE_DSP_MIN_API_VERSION);
-  try
-  {
-    m_apiVersion = AddonVersion(m_pStruct->GetAudioDSPAPIVersion());
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException("GetAudioDSPAPIVersion()");
-    return false;
-  }
+  m_apiVersion = AddonVersion(m_pStruct->GetAudioDSPAPIVersion());
 
   if (!IsCompatibleAPIVersion(minVersion, m_apiVersion))
   {
@@ -241,18 +203,8 @@ bool CActiveAEDSPAddon::CheckAPIVersion(void)
   }
 
   /* check the GUI API version */
-  AddonVersion guiVersion = AddonVersion("0.0.0");
+  AddonVersion guiVersion = AddonVersion(m_pStruct->GetGUIAPIVersion());
   minVersion = AddonVersion(KODI_GUILIB_MIN_API_VERSION);
-  try
-  {
-    guiVersion = AddonVersion(m_pStruct->GetGUIAPIVersion());
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException("GetGUIAPIVersion()");
-    return false;
-  }
 
   if (!IsCompatibleGUIAPIVersion(minVersion, guiVersion))
   {
@@ -265,53 +217,25 @@ bool CActiveAEDSPAddon::CheckAPIVersion(void)
 
 bool CActiveAEDSPAddon::GetAddonProperties(void)
 {
-  std::string strDSPName, strFriendlyName, strAudioDSPVersion;
   AE_DSP_ADDON_CAPABILITIES addonCapabilities;
 
   /* get the capabilities */
-  try
+  memset(&addonCapabilities, 0, sizeof(addonCapabilities));
+  AE_DSP_ERROR retVal = m_pStruct->GetAddonCapabilities(&addonCapabilities);
+  if (retVal != AE_DSP_ERROR_NO_ERROR)
   {
-    memset(&addonCapabilities, 0, sizeof(addonCapabilities));
-    AE_DSP_ERROR retVal = m_pStruct->GetAddonCapabilities(&addonCapabilities);
-    if (retVal != AE_DSP_ERROR_NO_ERROR)
-    {
-      CLog::Log(LOGERROR, "ActiveAE DSP - couldn't get the capabilities for add-on '%s'. Please contact the developer of this add-on: %s", GetFriendlyName().c_str(), Author().c_str());
-      return false;
-    }
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException("GetAddonCapabilities()");
+    CLog::Log(LOGERROR, "ActiveAE DSP - couldn't get the capabilities for add-on '%s'. Please contact the developer of this add-on: %s", GetFriendlyName().c_str(), Author().c_str());
     return false;
   }
 
   /* get the name of the dsp addon */
-  try
-  {
-    strDSPName = m_pStruct->GetDSPName();
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException("GetDSPName()");
-    return false;
-  }
+  std::string strDSPName = m_pStruct->GetDSPName();
 
   /* display name = backend name string */
-  strFriendlyName = StringUtils::Format("%s", strDSPName.c_str());
+  std::string strFriendlyName = StringUtils::Format("%s", strDSPName.c_str());
 
   /* backend version number */
-  try
-  {
-    strAudioDSPVersion = m_pStruct->GetDSPVersion();
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException("GetDSPVersion()");
-    return false;
-  }
+  std::string strAudioDSPVersion = m_pStruct->GetDSPVersion();
 
   /* update the members */
   m_strAudioDSPName     = strDSPName;
@@ -366,303 +290,111 @@ void CActiveAEDSPAddon::CallMenuHook(const AE_DSP_MENUHOOK &hook, AE_DSP_MENUHOO
   if (!m_bReadyToUse || hookData.category == AE_DSP_MENUHOOK_UNKNOWN)
     return;
 
-  try
-  {
-    m_pStruct->MenuHook(hook, hookData);
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
+  m_pStruct->MenuHook(hook, hookData);
 }
 
 AE_DSP_ERROR CActiveAEDSPAddon::StreamCreate(const AE_DSP_SETTINGS *addonSettings, const AE_DSP_STREAM_PROPERTIES* pProperties, ADDON_HANDLE handle)
 {
-  AE_DSP_ERROR retVal(AE_DSP_ERROR_UNKNOWN);
-
-  try
-  {
-    retVal = m_pStruct->StreamCreate(addonSettings, pProperties, handle);
-    if (retVal == AE_DSP_ERROR_NO_ERROR)
-      m_isInUse = true;
-    LogError(retVal, __FUNCTION__);
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
+  AE_DSP_ERROR retVal = m_pStruct->StreamCreate(addonSettings, pProperties, handle);
+  if (retVal == AE_DSP_ERROR_NO_ERROR)
+    m_isInUse = true;
+  LogError(retVal, __FUNCTION__);
 
   return retVal;
 }
 
 void CActiveAEDSPAddon::StreamDestroy(const ADDON_HANDLE handle)
 {
-  try
-  {
-    m_pStruct->StreamDestroy(handle);
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
+  m_pStruct->StreamDestroy(handle);
 
   m_isInUse = false;
 }
 
 bool CActiveAEDSPAddon::StreamIsModeSupported(const ADDON_HANDLE handle, AE_DSP_MODE_TYPE type, unsigned int addon_mode_id, int unique_db_mode_id)
 {
-  try
-  {
-    AE_DSP_ERROR retVal = m_pStruct->StreamIsModeSupported(handle, type, addon_mode_id, unique_db_mode_id);
-    if (retVal == AE_DSP_ERROR_NO_ERROR)
-      return true;
-    else if (retVal != AE_DSP_ERROR_IGNORE_ME)
-      LogError(retVal, __FUNCTION__);
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
+  AE_DSP_ERROR retVal = m_pStruct->StreamIsModeSupported(handle, type, addon_mode_id, unique_db_mode_id);
+  if (retVal == AE_DSP_ERROR_NO_ERROR)
+    return true;
+  else if (retVal != AE_DSP_ERROR_IGNORE_ME)
+    LogError(retVal, __FUNCTION__);
 
   return false;
 }
 
 AE_DSP_ERROR CActiveAEDSPAddon::StreamInitialize(const ADDON_HANDLE handle, const AE_DSP_SETTINGS *addonSettings)
 {
-  AE_DSP_ERROR retVal(AE_DSP_ERROR_UNKNOWN);
-
-  try
-  {
-    retVal = m_pStruct->StreamInitialize(handle, addonSettings);
-    LogError(retVal, __FUNCTION__);
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
+  AE_DSP_ERROR retVal = m_pStruct->StreamInitialize(handle, addonSettings);
+  LogError(retVal, __FUNCTION__);
 
   return retVal;
 }
 
 bool CActiveAEDSPAddon::InputProcess(const ADDON_HANDLE handle, const float **array_in, unsigned int samples)
 {
-  try
-  {
-    return m_pStruct->InputProcess(handle, array_in, samples);
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
-
-  return 0;
+  return m_pStruct->InputProcess(handle, array_in, samples);
 }
 
 unsigned int CActiveAEDSPAddon::InputResampleProcessNeededSamplesize(const ADDON_HANDLE handle)
 {
-  try
-  {
-    return m_pStruct->InputResampleProcessNeededSamplesize(handle);
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
-
-  return 0;
+  return m_pStruct->InputResampleProcessNeededSamplesize(handle);
 }
 
 unsigned int CActiveAEDSPAddon::InputResampleProcess(const ADDON_HANDLE handle, float **array_in, float **array_out, unsigned int samples)
 {
-  try
-  {
-    return m_pStruct->InputResampleProcess(handle, array_in, array_out, samples);
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
-
-  return 0;
+  return m_pStruct->InputResampleProcess(handle, array_in, array_out, samples);
 }
 
 int CActiveAEDSPAddon::InputResampleSampleRate(const ADDON_HANDLE handle)
 {
-  try
-  {
-    return m_pStruct->InputResampleSampleRate(handle);
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
-
-  return -1;
+  return m_pStruct->InputResampleSampleRate(handle);
 }
 
 float CActiveAEDSPAddon::InputResampleGetDelay(const ADDON_HANDLE handle)
 {
-  try
-  {
-    return m_pStruct->InputResampleGetDelay(handle);
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
-
-  return 0.0f;
+  return m_pStruct->InputResampleGetDelay(handle);
 }
 
 unsigned int CActiveAEDSPAddon::PreProcessNeededSamplesize(const ADDON_HANDLE handle, unsigned int mode_id)
 {
-  try
-  {
-    return m_pStruct->PreProcessNeededSamplesize(handle, mode_id);
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
-
-  return 0;
+  return m_pStruct->PreProcessNeededSamplesize(handle, mode_id);
 }
 
 float CActiveAEDSPAddon::PreProcessGetDelay(const ADDON_HANDLE handle, unsigned int mode_id)
 {
-  try
-  {
-    return m_pStruct->PreProcessGetDelay(handle, mode_id);
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
-
-  return 0.0f;
+  return m_pStruct->PreProcessGetDelay(handle, mode_id);
 }
 
 unsigned int CActiveAEDSPAddon::PreProcess(const ADDON_HANDLE handle, unsigned int mode_id, float **array_in, float **array_out, unsigned int samples)
 {
-  try
-  {
-    return m_pStruct->PostProcess(handle, mode_id, array_in, array_out, samples);
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
-
-  return 0;
+  return m_pStruct->PostProcess(handle, mode_id, array_in, array_out, samples);
 }
 
 AE_DSP_ERROR CActiveAEDSPAddon::MasterProcessSetMode(const ADDON_HANDLE handle, AE_DSP_STREAMTYPE type, unsigned int mode_id, int unique_db_mode_id)
 {
-  AE_DSP_ERROR retVal(AE_DSP_ERROR_UNKNOWN);
-
-  try
-  {
-    retVal = m_pStruct->MasterProcessSetMode(handle, type, mode_id, unique_db_mode_id);
-    LogError(retVal, __FUNCTION__);
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
+  AE_DSP_ERROR retVal = m_pStruct->MasterProcessSetMode(handle, type, mode_id, unique_db_mode_id);
+  LogError(retVal, __FUNCTION__);
 
   return retVal;
 }
 
 unsigned int CActiveAEDSPAddon::MasterProcessNeededSamplesize(const ADDON_HANDLE handle)
 {
-  try
-  {
-    return m_pStruct->MasterProcessNeededSamplesize(handle);
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
-
-  return 0;
+  return m_pStruct->MasterProcessNeededSamplesize(handle);
 }
 
 float CActiveAEDSPAddon::MasterProcessGetDelay(const ADDON_HANDLE handle)
 {
-  try
-  {
-    return m_pStruct->MasterProcessGetDelay(handle);
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
-
-  return 0.0f;
+  return m_pStruct->MasterProcessGetDelay(handle);
 }
 
 int CActiveAEDSPAddon::MasterProcessGetOutChannels(const ADDON_HANDLE handle, unsigned long &out_channel_present_flags)
 {
-  try
-  {
-    return m_pStruct->MasterProcessGetOutChannels(handle, out_channel_present_flags);
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
-
-  return -1;
+  return m_pStruct->MasterProcessGetOutChannels(handle, out_channel_present_flags);
 }
 
 unsigned int CActiveAEDSPAddon::MasterProcess(const ADDON_HANDLE handle, float **array_in, float **array_out, unsigned int samples)
 {
-  try
-  {
-    return m_pStruct->MasterProcess(handle, array_in, array_out, samples);
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
-
-  return 0;
+  return m_pStruct->MasterProcess(handle, array_in, array_out, samples);
 }
 
 std::string CActiveAEDSPAddon::MasterProcessGetStreamInfoString(const ADDON_HANDLE handle)
@@ -672,130 +404,43 @@ std::string CActiveAEDSPAddon::MasterProcessGetStreamInfoString(const ADDON_HAND
   if (!m_bReadyToUse)
     return strReturn;
 
-  try
-  {
-    strReturn = m_pStruct->MasterProcessGetStreamInfoString(handle);
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
-
+  strReturn = m_pStruct->MasterProcessGetStreamInfoString(handle);
   return strReturn;
 }
 
 unsigned int CActiveAEDSPAddon::PostProcessNeededSamplesize(const ADDON_HANDLE handle, unsigned int mode_id)
 {
-  try
-  {
-    return m_pStruct->PostProcessNeededSamplesize(handle, mode_id);
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
-
-  return 0;
+  return m_pStruct->PostProcessNeededSamplesize(handle, mode_id);
 }
 
 float CActiveAEDSPAddon::PostProcessGetDelay(const ADDON_HANDLE handle, unsigned int mode_id)
 {
-  try
-  {
-    return m_pStruct->PostProcessGetDelay(handle, mode_id);
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
-
-  return 0.0f;
+  return m_pStruct->PostProcessGetDelay(handle, mode_id);
 }
 
 unsigned int CActiveAEDSPAddon::PostProcess(const ADDON_HANDLE handle, unsigned int mode_id, float **array_in, float **array_out, unsigned int samples)
 {
-  try
-  {
-    return m_pStruct->PostProcess(handle, mode_id, array_in, array_out, samples);
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
-
-  return 0;
+  return m_pStruct->PostProcess(handle, mode_id, array_in, array_out, samples);
 }
 
 unsigned int CActiveAEDSPAddon::OutputResampleProcessNeededSamplesize(const ADDON_HANDLE handle)
 {
-  try
-  {
-    return m_pStruct->OutputResampleProcessNeededSamplesize(handle);
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
-
-  return 0;
+  return m_pStruct->OutputResampleProcessNeededSamplesize(handle);
 }
 
 unsigned int CActiveAEDSPAddon::OutputResampleProcess(const ADDON_HANDLE handle, float **array_in, float **array_out, unsigned int samples)
 {
-  try
-  {
-    return m_pStruct->OutputResampleProcess(handle, array_in, array_out, samples);
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
-
-  return 0;
+  return m_pStruct->OutputResampleProcess(handle, array_in, array_out, samples);
 }
 
 int CActiveAEDSPAddon::OutputResampleSampleRate(const ADDON_HANDLE handle)
 {
-  try
-  {
-    return m_pStruct->OutputResampleSampleRate(handle);
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
-
-  return -1;
+  return m_pStruct->OutputResampleSampleRate(handle);
 }
 
 float CActiveAEDSPAddon::OutputResampleGetDelay(const ADDON_HANDLE handle)
 {
-  try
-  {
-    return m_pStruct->OutputResampleGetDelay(handle);
-  }
-  XBMCCOMMONS_HANDLE_UNCHECKED
-  catch (...)
-  {
-    LogUnhandledException(__FUNCTION__);
-    Destroy();
-  }
-
-  return 0.0f;
+  return m_pStruct->OutputResampleGetDelay(handle);
 }
 
 bool CActiveAEDSPAddon::SupportsInputInfoProcess(void) const
@@ -863,9 +508,4 @@ bool CActiveAEDSPAddon::LogError(const AE_DSP_ERROR error, const char *strMethod
     return false;
   }
   return true;
-}
-
-void CActiveAEDSPAddon::LogUnhandledException(const char *strFunctionName) const
-{
-  CLog::Log(LOGERROR, "ActiveAE DSP - Unhandled exception caught while trying to call '%s' on add-on '%s', becomes diabled. Please contact the developer of this add-on: %s", strFunctionName, GetFriendlyName().c_str(), Author().c_str());
 }

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSPAddon.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSPAddon.h
@@ -404,7 +404,6 @@ namespace ActiveAE
     bool GetAddonProperties(void);
 
     bool LogError(const AE_DSP_ERROR error, const char *strMethod) const;
-    void LogUnhandledException(const char *strFunctionName) const;
 
     bool                      m_bReadyToUse;            /*!< true if this add-on is connected to the audio DSP, false otherwise */
     bool                      m_isInUse;                /*!< true if this add-on currentyl processing data */

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -264,8 +264,7 @@ bool CGameClient::OpenFile(const CFileItem& file, IGameAudioCallback* audio, IGa
 
   GAME_ERROR error = GAME_ERROR_FAILED;
 
-  try { LogError(error = m_pStruct->LoadGame(path.c_str()), "LoadGame()"); }
-  catch (...) { LogException("LoadGame()"); }
+  LogError(error = m_pStruct->LoadGame(path.c_str()), "LoadGame()");
 
   if (error != GAME_ERROR_NO_ERROR)
   {
@@ -292,9 +291,7 @@ bool CGameClient::OpenStandalone(IGameAudioCallback* audio, IGameVideoCallback* 
 
   GAME_ERROR error = GAME_ERROR_FAILED;
 
-  try { LogError(error = m_pStruct->LoadStandalone(), "LoadStandalone()"); }
-  catch (...) { LogException("LoadStandalone()"); }
-
+  LogError(error = m_pStruct->LoadStandalone(), "LoadStandalone()");
   if (error != GAME_ERROR_NO_ERROR)
   {
     NotifyError(error);
@@ -366,16 +363,11 @@ bool CGameClient::LoadGameInfo()
   // Can be called only after retro_load_game()
   game_system_av_info av_info = { };
 
-  bool bSuccess = false;
-  try { bSuccess = LogError(m_pStruct->GetGameInfo(&av_info), "GetGameInfo()"); }
-  catch (...) { LogException("GetGameInfo()"); }
-
+  bool bSuccess = LogError(m_pStruct->GetGameInfo(&av_info), "GetGameInfo()");
   if (!bSuccess)
     return false;
 
-  GAME_REGION region;
-  try { region = m_pStruct->GetRegion(); }
-  catch (...) { LogException("GetRegion()"); return false; }
+  GAME_REGION region = m_pStruct->GetRegion();
 
   CLog::Log(LOGINFO, "GAME: ---------------------------------------");
   CLog::Log(LOGINFO, "GAME: Base Width:   %u", av_info.geometry.base_width);
@@ -443,11 +435,7 @@ std::string CGameClient::GetMissingResource()
 
 void CGameClient::CreatePlayback()
 {
-  bool bRequiresGameLoop = false;
-
-  try { bRequiresGameLoop = m_pStruct->RequiresGameLoop(); }
-  catch (...) { LogException("RequiresGameLoop()"); }
-
+  bool bRequiresGameLoop = m_pStruct->RequiresGameLoop();
   if (bRequiresGameLoop)
   {
     m_playback.reset(new CGameClientReversiblePlayback(this, m_timing.GetFrameRate(), m_serializeSize));
@@ -471,8 +459,7 @@ void CGameClient::Reset()
 
   if (m_bIsPlaying)
   {
-    try { LogError(m_pStruct->Reset(), "Reset()"); }
-    catch (...) { LogException("Reset()"); }
+    LogError(m_pStruct->Reset(), "Reset()");
 
     CreatePlayback();
   }
@@ -486,8 +473,7 @@ void CGameClient::CloseFile()
 
   if (m_bIsPlaying)
   {
-    try { LogError(m_pStruct->UnloadGame(), "UnloadGame()"); }
-    catch (...) { LogException("UnloadGame()"); }
+    LogError(m_pStruct->UnloadGame(), "UnloadGame()");
   }
 
   ClearPorts();
@@ -518,8 +504,7 @@ void CGameClient::RunFrame()
 
   if (m_bIsPlaying)
   {
-    try { LogError(m_pStruct->RunFrame(), "RunFrame()"); }
-    catch (...) { LogException("RunFrame()"); }
+    LogError(m_pStruct->RunFrame(), "RunFrame()");
   }
 }
 
@@ -672,8 +657,7 @@ size_t CGameClient::GetSerializeSize()
   size_t serializeSize = 0;
   if (m_bIsPlaying)
   {
-    try { serializeSize = m_pStruct->SerializeSize(); }
-    catch (...) { LogException("SerializeSize()"); }
+    serializeSize = m_pStruct->SerializeSize();
   }
 
   return serializeSize;
@@ -689,8 +673,7 @@ bool CGameClient::Serialize(uint8_t* data, size_t size)
   bool bSuccess = false;
   if (m_bIsPlaying)
   {
-    try { bSuccess = LogError(m_pStruct->Serialize(data, size), "Serialize()"); }
-    catch (...) { LogException("Serialize()"); }
+    bSuccess = LogError(m_pStruct->Serialize(data, size), "Serialize()");
   }
 
   return bSuccess;
@@ -706,8 +689,7 @@ bool CGameClient::Deserialize(const uint8_t* data, size_t size)
   bool bSuccess = false;
   if (m_bIsPlaying)
   {
-    try { bSuccess = LogError(m_pStruct->Deserialize(data, size), "Deserialize()"); }
-    catch (...) { LogException("Deserialize()"); }
+    bSuccess = LogError(m_pStruct->Deserialize(data, size), "Deserialize()");
   }
 
   return bSuccess;
@@ -778,13 +760,11 @@ void CGameClient::UpdatePort(unsigned int port, const ControllerPtr& controller)
     controllerStruct.abs_pointer_count    = 0; //! @todo
     controllerStruct.motor_count          = controller->Layout().FeatureCount(FEATURE_TYPE::MOTOR);
 
-    try { m_pStruct->UpdatePort(port, true, &controllerStruct); }
-    catch (...) { LogException("UpdatePort()"); }
+    m_pStruct->UpdatePort(port, true, &controllerStruct);
   }
   else
   {
-    try { m_pStruct->UpdatePort(port, false, nullptr); }
-    catch (...) { LogException("UpdatePort()"); }
+    m_pStruct->UpdatePort(port, false, nullptr);
   }
 }
 
@@ -874,14 +854,12 @@ void CGameClient::OpenMouse(void)
 
   game_controller controllerStruct = { strId.c_str() };
 
-  try { m_pStruct->UpdatePort(GAME_INPUT_PORT_MOUSE, true, &controllerStruct); }
-  catch (...) { LogException("UpdatePort()"); }
+  m_pStruct->UpdatePort(GAME_INPUT_PORT_MOUSE, true, &controllerStruct);
 }
 
 void CGameClient::CloseMouse(void)
 {
-  try { m_pStruct->UpdatePort(GAME_INPUT_PORT_MOUSE, false, nullptr); }
-  catch (...) { LogException("UpdatePort()"); }
+  m_pStruct->UpdatePort(GAME_INPUT_PORT_MOUSE, false, nullptr);
 
   m_mouse.reset();
 }
@@ -908,11 +886,4 @@ bool CGameClient::LogError(GAME_ERROR error, const char* strMethod) const
     return false;
   }
   return true;
-}
-
-void CGameClient::LogException(const char* strFunctionName) const
-{
-  CLog::Log(LOGERROR, "GAME: exception caught while trying to call '%s' on add-on %s",
-      strFunctionName, ID().c_str());
-  CLog::Log(LOGERROR, "Please contact the developer of this add-on: %s", Author().c_str());
 }

--- a/xbmc/games/addons/GameClient.h
+++ b/xbmc/games/addons/GameClient.h
@@ -136,7 +136,6 @@ private:
   // Helper functions
   void LogAddonProperties(void) const;
   bool LogError(GAME_ERROR error, const char* strMethod) const;
-  void LogException(const char* strFunctionName) const;
 
   // Add-on properties
   ADDON::AddonVersion   m_apiVersion;

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -127,8 +127,6 @@ ADDON::AddonPtr CPeripheralAddon::GetRunningInstance(void) const
 
 ADDON_STATUS CPeripheralAddon::CreateAddon(void)
 {
-  ADDON_STATUS status(ADDON_STATUS_UNKNOWN);
-
   // Reset all properties to defaults
   ResetProperties();
 
@@ -138,9 +136,7 @@ ADDON_STATUS CPeripheralAddon::CreateAddon(void)
 
   // Initialise the add-on
   CLog::Log(LOGDEBUG, "PERIPHERAL - %s - creating peripheral add-on instance '%s'", __FUNCTION__, Name().c_str());
-  try { status = CAddonDll<DllPeripheral, PeripheralAddon, PERIPHERAL_PROPERTIES>::Create(); }
-  catch (const std::exception& e) { LogException(e, __FUNCTION__); }
-
+  ADDON_STATUS status = CAddonDll<DllPeripheral, PeripheralAddon, PERIPHERAL_PROPERTIES>::Create();
   if (status == ADDON_STATUS_OK)
   {
     if (!GetAddonProperties())
@@ -158,17 +154,13 @@ bool CPeripheralAddon::GetAddonProperties(void)
   PERIPHERAL_CAPABILITIES addonCapabilities = { };
 
   // Get the capabilities
-  try
+  PERIPHERAL_ERROR retVal = m_pStruct->GetAddonCapabilities(&addonCapabilities);
+  if (retVal != PERIPHERAL_NO_ERROR)
   {
-    PERIPHERAL_ERROR retVal = m_pStruct->GetAddonCapabilities(&addonCapabilities);
-    if (retVal != PERIPHERAL_NO_ERROR)
-    {
-      CLog::Log(LOGERROR, "PERIPHERAL - couldn't get the capabilities for add-on '%s'. Please contact the developer of this add-on: %s",
-          Name().c_str(), Author().c_str());
-      return false;
-    }
+    CLog::Log(LOGERROR, "PERIPHERAL - couldn't get the capabilities for add-on '%s'. Please contact the developer of this add-on: %s",
+        Name().c_str(), Author().c_str());
+    return false;
   }
-  catch (std::exception& e) { LogException(e, "GetAddonCapabilities()"); return false; }
 
   // Verify capabilities against addon.xml
   if (m_bProvidesJoysticks != addonCapabilities.provides_joysticks)
@@ -193,8 +185,7 @@ bool CPeripheralAddon::CheckAPIVersion(void)
 {
   // Check the API version
   ADDON::AddonVersion minVersion = ADDON::AddonVersion(PERIPHERAL_MIN_API_VERSION);
-  try { m_apiVersion = ADDON::AddonVersion(m_pStruct->GetPeripheralAPIVersion()); }
-  catch (std::exception &e) { LogException(e, "GetPeripheralAPIVersion()"); return false; }
+  m_apiVersion = ADDON::AddonVersion(m_pStruct->GetPeripheralAPIVersion());
 
   if (!IsCompatibleAPIVersion(minVersion, m_apiVersion))
   {
@@ -369,9 +360,7 @@ bool CPeripheralAddon::PerformDeviceScan(PeripheralScanResults &results)
   PERIPHERAL_INFO*  pScanResults;
   PERIPHERAL_ERROR  retVal;
 
-  try { LogError(retVal = m_pStruct->PerformDeviceScan(&peripheralCount, &pScanResults), "PerformDeviceScan()"); }
-  catch (std::exception &e) { LogException(e, "PerformDeviceScan()"); return false;  }
-
+  LogError(retVal = m_pStruct->PerformDeviceScan(&peripheralCount, &pScanResults), "PerformDeviceScan()");
   if (retVal == PERIPHERAL_NO_ERROR)
   {
     for (unsigned int i = 0; i < peripheralCount; i++)
@@ -400,8 +389,7 @@ bool CPeripheralAddon::PerformDeviceScan(PeripheralScanResults &results)
         results.m_results.push_back(result);
     }
 
-    try { m_pStruct->FreeScanResults(peripheralCount, pScanResults); }
-    catch (std::exception &e) { LogException(e, "FreeJoysticks()"); }
+    m_pStruct->FreeScanResults(peripheralCount, pScanResults);
 
     return true;
   }
@@ -419,9 +407,7 @@ bool CPeripheralAddon::ProcessEvents(void)
   unsigned int      eventCount = 0;
   PERIPHERAL_EVENT* pEvents = NULL;
 
-  try { LogError(retVal = m_pStruct->GetEvents(&eventCount, &pEvents), "GetEvents()"); }
-  catch (std::exception &e) { LogException(e, "GetEvents()"); return false;  }
-
+  LogError(retVal = m_pStruct->GetEvents(&eventCount, &pEvents), "GetEvents()");
   if (retVal == PERIPHERAL_NO_ERROR)
   {
     for (unsigned int i = 0; i < eventCount; i++)
@@ -478,8 +464,7 @@ bool CPeripheralAddon::ProcessEvents(void)
         std::static_pointer_cast<CPeripheralJoystick>(it.second)->ProcessAxisMotions();
     }
 
-    try { m_pStruct->FreeEvents(eventCount, pEvents); }
-    catch (std::exception &e) { LogException(e, "FreeEvents()"); }
+    m_pStruct->FreeEvents(eventCount, pEvents);
 
     return true;
   }
@@ -498,10 +483,7 @@ bool CPeripheralAddon::SendRumbleEvent(unsigned int peripheralIndex, unsigned in
   eventStruct.driver_index     = driverIndex;
   eventStruct.motor_state      = magnitude;
 
-  try { bHandled = m_pStruct->SendEvent(&eventStruct); }
-  catch (std::exception &e) { LogException(e, "SendEvent()"); }
-
-  return bHandled;
+  return m_pStruct->SendEvent(&eventStruct);
 }
 
 bool CPeripheralAddon::GetJoystickProperties(unsigned int index, CPeripheralJoystick& joystick)
@@ -513,16 +495,13 @@ bool CPeripheralAddon::GetJoystickProperties(unsigned int index, CPeripheralJoys
 
   JOYSTICK_INFO joystickStruct;
 
-  try { LogError(retVal = m_pStruct->GetJoystickInfo(index, &joystickStruct), "GetJoystickInfo()"); }
-  catch (std::exception &e) { LogException(e, "GetJoystickInfo()"); return false;  }
-
+  LogError(retVal = m_pStruct->GetJoystickInfo(index, &joystickStruct), "GetJoystickInfo()");
   if (retVal == PERIPHERAL_NO_ERROR)
   {
     ADDON::Joystick addonJoystick(joystickStruct);
     SetJoystickInfo(joystick, addonJoystick);
 
-    try { m_pStruct->FreeJoystickInfo(&joystickStruct); }
-    catch (std::exception &e) { LogException(e, "FreeJoystickInfo()"); }
+    m_pStruct->FreeJoystickInfo(&joystickStruct);
 
     return true;
   }
@@ -548,10 +527,8 @@ bool CPeripheralAddon::GetFeatures(const CPeripheral* device,
   unsigned int      featureCount = 0;
   JOYSTICK_FEATURE* pFeatures = NULL;
 
-  try { LogError(retVal = m_pStruct->GetFeatures(&joystickStruct, strControllerId.c_str(),
-                                                 &featureCount, &pFeatures), "GetFeatures()"); }
-  catch (std::exception &e) { LogException(e, "GetFeatures()"); return false;  }
-
+  LogError(retVal = m_pStruct->GetFeatures(&joystickStruct, strControllerId.c_str(),
+                                           &featureCount, &pFeatures), "GetFeatures()");
   if (retVal == PERIPHERAL_NO_ERROR)
   {
     for (unsigned int i = 0; i < featureCount; i++)
@@ -561,8 +538,7 @@ bool CPeripheralAddon::GetFeatures(const CPeripheral* device,
         features[feature.Name()] = std::move(feature);
     }
 
-    try { m_pStruct->FreeFeatures(featureCount, pFeatures); }
-    catch (std::exception &e) { LogException(e, "FreeFeatures()"); }
+    m_pStruct->FreeFeatures(featureCount, pFeatures);
 
     return true;
   }
@@ -588,10 +564,8 @@ bool CPeripheralAddon::MapFeature(const CPeripheral* device,
   JOYSTICK_FEATURE addonFeature;
   feature.ToStruct(addonFeature);
 
-  try { LogError(retVal = m_pStruct->MapFeatures(&joystickStruct, strControllerId.c_str(),
-                                                 1, &addonFeature), "MapFeatures()"); }
-  catch (std::exception &e) { LogException(e, "MapFeatures()"); return false;  }
-
+  LogError(retVal = m_pStruct->MapFeatures(&joystickStruct, strControllerId.c_str(),
+                                                 1, &addonFeature), "MapFeatures()");
   return retVal == PERIPHERAL_NO_ERROR;
 }
 
@@ -611,30 +585,14 @@ bool CPeripheralAddon::GetIgnoredPrimitives(const CPeripheral* device, Primitive
   unsigned int primitiveCount = 0;
   JOYSTICK_DRIVER_PRIMITIVE* pPrimitives = nullptr;
 
-  try
-  {
-    LogError(retVal = m_pStruct->GetIgnoredPrimitives(&joystickStruct, &primitiveCount,
+  LogError(retVal = m_pStruct->GetIgnoredPrimitives(&joystickStruct, &primitiveCount,
                                                       &pPrimitives), "GetIgnoredPrimitives()");
-  }
-  catch (std::exception &e)
-  {
-    LogException(e, "GetIgnoredPrimitives()");
-    return false; 
-  }
-
   if (retVal == PERIPHERAL_NO_ERROR)
   {
     for (unsigned int i = 0; i < primitiveCount; i++)
       primitives.emplace_back(pPrimitives[i]);
 
-    try
-    {
-      m_pStruct->FreePrimitives(primitiveCount, pPrimitives);
-    }
-    catch (std::exception &e)
-    {
-      LogException(e, "FreePrimitives()");
-    }
+    m_pStruct->FreePrimitives(primitiveCount, pPrimitives);
 
     return true;
   }
@@ -659,15 +617,8 @@ bool CPeripheralAddon::SetIgnoredPrimitives(const CPeripheral* device, const Pri
   JOYSTICK_DRIVER_PRIMITIVE* addonPrimitives = nullptr;
   ADDON::DriverPrimitives::ToStructs(primitives, &addonPrimitives);
 
-  try
-  {
-    LogError(retVal = m_pStruct->SetIgnoredPrimitives(&joystickStruct,
+  LogError(retVal = m_pStruct->SetIgnoredPrimitives(&joystickStruct,
         primitives.size(), addonPrimitives), "SetIgnoredPrimitives()");
-  }
-  catch (std::exception &e)
-  {
-    LogException(e, "SetIgnoredPrimitives()"); return false;
-  }
 
   ADDON::DriverPrimitives::FreeStructs(primitives.size(), addonPrimitives);
 
@@ -685,8 +636,7 @@ void CPeripheralAddon::SaveButtonMap(const CPeripheral* device)
   JOYSTICK_INFO joystickStruct;
   joystickInfo.ToStruct(joystickStruct);
 
-  try { m_pStruct->SaveButtonMap(&joystickStruct); }
-  catch (std::exception &e) { LogException(e, "SaveMap()"); return; }
+  m_pStruct->SaveButtonMap(&joystickStruct);
 
   // Notify observing button maps
   RefreshButtonMaps(device->DeviceName());
@@ -703,8 +653,7 @@ void CPeripheralAddon::RevertButtonMap(const CPeripheral* device)
   JOYSTICK_INFO joystickStruct;
   joystickInfo.ToStruct(joystickStruct);
 
-  try { m_pStruct->RevertButtonMap(&joystickStruct); }
-  catch (std::exception &e) { LogException(e, "RevertMap()"); return; }
+  m_pStruct->RevertButtonMap(&joystickStruct);
 }
 
 void CPeripheralAddon::ResetButtonMap(const CPeripheral* device, const std::string& strControllerId)
@@ -718,8 +667,7 @@ void CPeripheralAddon::ResetButtonMap(const CPeripheral* device, const std::stri
   JOYSTICK_INFO joystickStruct;
   joystickInfo.ToStruct(joystickStruct);
 
-  try { m_pStruct->ResetButtonMap(&joystickStruct, strControllerId.c_str()); }
-  catch (std::exception &e) { LogException(e, "ResetButtonMap()"); return; }
+  m_pStruct->ResetButtonMap(&joystickStruct, strControllerId.c_str());
 
   // Notify observing button maps
   RefreshButtonMaps(device->DeviceName());
@@ -730,8 +678,7 @@ void CPeripheralAddon::PowerOffJoystick(unsigned int index)
   if (!HasFeature(FEATURE_JOYSTICK))
     return;
 
-  try { m_pStruct->PowerOffJoystick(index); }
-  catch (std::exception &e) { LogException(e, "PowerOffJoystick()"); return; }
+  m_pStruct->PowerOffJoystick(index);
 }
 
 void CPeripheralAddon::RegisterButtonMap(CPeripheral* device, IButtonMap* buttonMap)
@@ -829,10 +776,4 @@ bool CPeripheralAddon::LogError(const PERIPHERAL_ERROR error, const char *strMet
     return false;
   }
   return true;
-}
-
-void CPeripheralAddon::LogException(const std::exception &e, const char *strFunctionName) const
-{
-  CLog::Log(LOGERROR, "PERIPHERAL - exception '%s' caught while trying to call '%s' on add-on '%s'. Please contact the developer of this add-on: %s",
-            e.what(), strFunctionName, Name().c_str(), Author().c_str());
 }

--- a/xbmc/peripherals/addons/PeripheralAddon.h
+++ b/xbmc/peripherals/addons/PeripheralAddon.h
@@ -136,7 +136,6 @@ namespace PERIPHERALS
     static bool IsCompatibleAPIVersion(const ADDON::AddonVersion &minVersion, const ADDON::AddonVersion &version);
 
     bool LogError(const PERIPHERAL_ERROR error, const char *strMethod) const;
-    void LogException(const std::exception &e, const char *strFunctionName) const;
 
     /* @brief Cache for const char* members in PERIPHERAL_PROPERTIES */
     std::string         m_strUserPath;    /*!< @brief translated path to the user profile */


### PR DESCRIPTION
This remove the not good usable use of `try` and `catch` on PVR add-on handling.

@FernetMenta Is the remove of them the right way? If yes becomes it also done on other add-on types.