### PR TITLE
[addons] rename structures to more clear names

### DIFF
--- a/xbmc/addons/AudioDecoder.h
+++ b/xbmc/addons/AudioDecoder.h
@@ -79,7 +79,7 @@ namespace ADDON
     bool m_tracks;
     const AEChannel* m_channel;
     AUDIODEC_PROPS m_info;
-    AudioDecoder m_struct;
+    KodiToAddonFuncTable_AudioDecoder m_struct;
   };
 
 } /*namespace ADDON*/

--- a/xbmc/addons/AudioEncoder.h
+++ b/xbmc/addons/AudioEncoder.h
@@ -46,7 +46,7 @@ namespace ADDON
   private:
     void *m_context; ///< audio encoder context
     AUDIOENC_PROPS m_info;
-    AudioEncoder m_struct;
+    KodiToAddonFuncTable_AudioEncoder m_struct;
   };
 
 } /*namespace ADDON*/

--- a/xbmc/addons/InputStream.h
+++ b/xbmc/addons/InputStream.h
@@ -113,7 +113,7 @@ namespace ADDON
 
   private:
     INPUTSTREAM_PROPS m_info;
-    InputStreamAddonFunctions m_struct;
+    KodiToAddonFuncTable_InputStream m_struct;
   };
 
 } /*namespace ADDON*/

--- a/xbmc/addons/PVRClient.h
+++ b/xbmc/addons/PVRClient.h
@@ -742,6 +742,6 @@ namespace PVR
     ADDON::AddonVersion m_apiVersion;
     bool                m_bAvahiServiceAdded;
     PVR_PROPERTIES      m_info;
-    PVRClient           m_struct;
+    KodiToAddonFuncTable_PVR m_struct;
   };
 }

--- a/xbmc/addons/ScreenSaver.h
+++ b/xbmc/addons/ScreenSaver.h
@@ -42,7 +42,7 @@ public:
 
 private:
   SCR_PROPS m_info;
-  ScreenSaver m_struct;
+  KodiToAddonFuncTable_Screensaver m_struct;
 };
 
 } /*namespace ADDON*/

--- a/xbmc/addons/Visualisation.h
+++ b/xbmc/addons/Visualisation.h
@@ -106,6 +106,6 @@ namespace ADDON
     std::string m_AlbumThumb;
     
     VIS_PROPS m_info;
-    Visualisation m_struct;
+    KodiToAddonFuncTable_Visualisation m_struct;
   };
 }

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_adsp_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_adsp_dll.h
@@ -519,7 +519,7 @@ extern "C"
   // function to export the above structure to KODI
   void __declspec(dllexport) get_addon(void* ptr)
   {
-    AudioDSP* pDSP = static_cast<AudioDecoder*>(ptr);
+    KodiToAddonFuncTable_AudioDSP* pDSP = static_cast<KodiToAddonFuncTable_AudioDSP*>(ptr);
 
     pDSP->GetAudioDSPAPIVersion                 = GetAudioDSPAPIVersion;
     pDSP->GetMinimumAudioDSPAPIVersion          = GetMinimumAudioDSPAPIVersion;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_adsp_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_adsp_types.h
@@ -474,7 +474,7 @@ extern "C" {
   /*!
    * @brief Structure to transfer the methods from kodi_audiodsp_dll.h to KODI
    */
-  struct AudioDSP
+  typedef struct KodiToAddonFuncTable_AudioDSP
   {
     const char*  (__cdecl* GetAudioDSPAPIVersion)                (void);
     const char*  (__cdecl* GetMinimumAudioDSPAPIVersion)         (void);
@@ -516,7 +516,7 @@ extern "C" {
     unsigned int (__cdecl* OutputResampleProcess)                (const ADDON_HANDLE, float**, float**, unsigned int);
     float        (__cdecl* OutputResampleGetDelay)               (const ADDON_HANDLE);
     int          (__cdecl* OutputResampleSampleRate)             (const ADDON_HANDLE);
-  };
+  } KodiToAddonFuncTable_AudioDSP;
 
 #ifdef __cplusplus
 }

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_audiodec_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_audiodec_dll.h
@@ -50,7 +50,7 @@ extern "C"
   // function to export the above structure to XBMC
   void __declspec(dllexport) get_addon(void* ptr)
   {
-    AudioDecoder* pScr = static_cast<AudioDecoder*>(ptr);
+    KodiToAddonFuncTable_AudioDecoder* pScr = static_cast<KodiToAddonFuncTable_AudioDecoder*>(ptr);
 
     pScr->Init = Init;
     pScr->ReadPCM = ReadPCM;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_audiodec_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_audiodec_types.h
@@ -39,7 +39,7 @@ extern "C"
     int dummy;
   };
 
-  struct AudioDecoder
+  typedef struct KodiToAddonFuncTable_AudioDecoder
   {
     //! \brief Initialize a decoder
     //! \param file The file to read
@@ -97,5 +97,5 @@ extern "C"
     //! \return True on success, false on failure
     //! \sa ICodec::DeInit
     bool (__cdecl* DeInit)(void* context);
-  };
+  } KodiToAddonFuncTable_AudioDecoder;
 }

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_dll.h
@@ -256,7 +256,7 @@ GAME_ERROR SetCheat(unsigned int index, bool enabled, const char* code);
  */
 void __declspec(dllexport) get_addon(void* ptr)
 {
-  GameClient* pClient = static_cast<GameClient*>(ptr);
+  KodiToAddonFuncTable_Game* pClient = static_cast<KodiToAddonFuncTable_Game*>(ptr);
 
   pClient->GetGameAPIVersion        = GetGameAPIVersion;
   pClient->GetMininumGameAPIVersion = GetMininumGameAPIVersion;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h
@@ -454,7 +454,7 @@ typedef struct game_client_properties
 } game_client_properties;
 
 /*! Structure to transfer the methods from kodi_game_dll.h to Kodi */
-typedef struct GameClient
+typedef struct KodiToAddonFuncTable_Game
 {
   const char* (__cdecl* GetGameAPIVersion)(void);
   const char* (__cdecl* GetMininumGameAPIVersion)(void);
@@ -478,7 +478,7 @@ typedef struct GameClient
   GAME_ERROR  (__cdecl* CheatReset)(void);
   GAME_ERROR  (__cdecl* GetMemory)(GAME_MEMORY, const uint8_t**, size_t*);
   GAME_ERROR  (__cdecl* SetCheat)(unsigned int, bool, const char*);
-} GameClient;
+} KodiToAddonFuncTable_Game;
 
 #ifdef __cplusplus
 }

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_dll.h
@@ -226,7 +226,7 @@ extern "C"
   */
   void __declspec(dllexport) get_addon(void* ptr)
   {
-    InputStreamAddonFunctions* pClient = static_cast<InputStreamAddonFunctions*>(ptr);
+    KodiToAddonFuncTable_InputStream* pClient = static_cast<KodiToAddonFuncTable_InputStream*>(ptr);
 
     pClient->Open = Open;
     pClient->Close = Close;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_types.h
@@ -124,7 +124,7 @@ extern "C" {
   /*!
    * @brief Structure to transfer the methods from xbmc_inputstream_dll.h to XBMC
    */
-  typedef struct InputStreamAddonFunctions
+  typedef struct KodiToAddonFuncTable_InputStream
   {
     bool (__cdecl* Open)(INPUTSTREAM&);
     void (__cdecl* Close)(void);
@@ -161,7 +161,7 @@ extern "C" {
     int64_t (__cdecl* LengthStream)(void);
     void (__cdecl* PauseStream)(double);
     bool (__cdecl* IsRealTimeStream)(void);
-  } InputStreamAddonFunctions;
+  } KodiToAddonFuncTable_InputStream;
 }
 
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_dll.h
@@ -232,7 +232,7 @@ extern "C"
    */
   void __declspec(dllexport) get_addon(void* ptr)
   {
-    PeripheralAddon* pClient = static_cast<PeripheralAddon*>(ptr);
+    KodiToAddonFuncTable_Peripheral* pClient = static_cast<KodiToAddonFuncTable_Peripheral*>(ptr);
 
     pClient->GetPeripheralAPIVersion        = GetPeripheralAPIVersion;
     pClient->GetMinimumPeripheralAPIVersion = GetMinimumPeripheralAPIVersion;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_types.h
@@ -288,7 +288,7 @@ extern "C"
   /*!
    * @brief Structure to transfer the methods from kodi_peripheral_dll.h to the frontend
    */
-  typedef struct PeripheralAddon
+  typedef struct KodiToAddonFuncTable_Peripheral
   {
     const char*      (__cdecl* GetPeripheralAPIVersion)(void);
     const char*      (__cdecl* GetMinimumPeripheralAPIVersion)(void);
@@ -314,7 +314,7 @@ extern "C"
     void             (__cdecl* ResetButtonMap)(const JOYSTICK_INFO*, const char*);
     void             (__cdecl* PowerOffJoystick)(unsigned int);
     ///}
-  } PeripheralAddon;
+  } KodiToAddonFuncTable_Peripheral;
 
 #ifdef __cplusplus
 }

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_audioenc_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_audioenc_dll.h
@@ -48,7 +48,7 @@ extern "C"
   // function to export the above structure to XBMC
   void __declspec(dllexport) get_addon(void* enc)
   {
-    AudioEncoder* pScr = static_cast<AudioEncoder*>(enc);
+    KodiToAddonFuncTable_AudioEncoder* pScr = static_cast<KodiToAddonFuncTable_AudioEncoder*>(enc);
 
     pScr->Create = Create;
     pScr->Start  = Start;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_audioenc_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_audioenc_types.h
@@ -55,7 +55,7 @@ extern "C"
     audioenc_seek_callback  seek;
   } audioenc_callbacks;
 
-  struct AudioEncoder
+  typedef struct KodiToAddonFuncTable_AudioEncoder
   {
     /*! \brief Create encoder context
      \param callbacks Pointer to audioenc_callbacks structure.
@@ -105,6 +105,6 @@ extern "C"
      \param context Encoder context to free.
      */
     void (__cdecl* Free)(void* context);
-  };
+  } KodiToAddonFuncTable_AudioEncoder;
 }
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
@@ -661,7 +661,7 @@ extern "C"
    */
   void __declspec(dllexport) get_addon(void* ptr)
   {
-    PVRClient* pClient = static_cast<PVRClient*>(ptr);
+    KodiToAddonFuncTable_PVR* pClient = static_cast<KodiToAddonFuncTable_PVR*>(ptr);
     
     pClient->GetPVRAPIVersion               = GetPVRAPIVersion;
     pClient->GetMininumPVRAPIVersion        = GetMininumPVRAPIVersion;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -530,7 +530,7 @@ extern "C" {
   /*!
    * @brief Structure to transfer the methods from xbmc_pvr_dll.h to XBMC
    */
-  typedef struct PVRClient
+  typedef struct KodiToAddonFuncTable_PVR
   {
     const char*  (__cdecl* GetPVRAPIVersion)(void);
     const char*  (__cdecl* GetMininumPVRAPIVersion)(void);
@@ -607,7 +607,7 @@ extern "C" {
     void         (__cdecl* OnSystemWake)(void);
     void         (__cdecl* OnPowerSavingActivated)(void);
     void         (__cdecl* OnPowerSavingDeactivated)(void);
-  } PVRClient;
+  } KodiToAddonFuncTable_PVR;
 
 #ifdef __cplusplus
 }

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_scr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_scr_dll.h
@@ -33,7 +33,7 @@ extern "C"
   // function to export the above structure to XBMC
   void __declspec(dllexport) get_addon(void* ptr)
   {
-    ScreenSaver* pScr = static_cast<ScreenSaver*>(ptr);
+    KodiToAddonFuncTable_Screensaver* pScr = static_cast<KodiToAddonFuncTable_Screensaver*>(ptr);
 
     pScr->Start = Start;
     pScr->Render = Render;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_scr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_scr_types.h
@@ -35,10 +35,10 @@ extern "C"
     const char *profile;
   };
 
-  struct ScreenSaver
+  typedef struct KodiToAddonFuncTable_Screensaver
   {
     void (__cdecl* Start) ();
     void (__cdecl* Render) ();
-  };
+  } KodiToAddonFuncTable_Screensaver;
 }
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_vis_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_vis_dll.h
@@ -39,7 +39,7 @@ extern "C"
   // function to export the above structure to XBMC
   void __declspec(dllexport) get_addon(void* ptr)
   {
-    Visualisation* pVisz = static_cast<Visualisation*>(ptr);
+    KodiToAddonFuncTable_Visualisation* pVisz = static_cast<KodiToAddonFuncTable_Visualisation*>(ptr);
 
     pVisz->Start = Start;
     pVisz->AudioData = AudioData;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_vis_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_vis_types.h
@@ -93,7 +93,7 @@ extern "C"
     int        reserved4;
   };
 
-  struct Visualisation
+  typedef struct KodiToAddonFuncTable_Visualisation
   {
     void (__cdecl* Start)(int iChannels, int iSamplesPerSec, int iBitsPerSample, const char* szSongName);
     void (__cdecl* AudioData)(const float* pAudioData, int iAudioDataLength, float *pFreqData, int iFreqDataLength);
@@ -105,6 +105,6 @@ extern "C"
     unsigned int (__cdecl *GetPreset)();
     unsigned int (__cdecl *GetSubModules)(char ***modules);
     bool (__cdecl* IsLocked)();
-  };
+  } KodiToAddonFuncTable_Visualisation;
 }
 

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSPAddon.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSPAddon.h
@@ -424,6 +424,6 @@ namespace ActiveAE
 
     ADDON::AddonVersion       m_apiVersion;
     AE_DSP_PROPERTIES         m_info;
-    AudioDSP                  m_struct;
+    KodiToAddonFuncTable_AudioDSP m_struct;
   };
 }

--- a/xbmc/games/addons/GameClient.h
+++ b/xbmc/games/addons/GameClient.h
@@ -168,7 +168,7 @@ private:
   CCriticalSection m_critSection;
   
   game_client_properties* m_info;
-  GameClient m_struct;
+  KodiToAddonFuncTable_Game m_struct;
 };
 
 } // namespace GAME

--- a/xbmc/games/addons/GameClientInput.cpp
+++ b/xbmc/games/addons/GameClientInput.cpp
@@ -29,7 +29,7 @@
 
 using namespace GAME;
 
-CGameClientInput::CGameClientInput(CGameClient* gameClient, int port, const ControllerPtr& controller, const GameClient *dllStruct) :
+CGameClientInput::CGameClientInput(CGameClient* gameClient, int port, const ControllerPtr& controller, const KodiToAddonFuncTable_Game *dllStruct) :
   m_gameClient(gameClient),
   m_port(port),
   m_controller(controller),

--- a/xbmc/games/addons/GameClientInput.h
+++ b/xbmc/games/addons/GameClientInput.h
@@ -22,7 +22,7 @@
 #include "games/controllers/ControllerTypes.h"
 #include "input/joysticks/IInputHandler.h"
 
-struct GameClient;
+struct KodiToAddonFuncTable_Game;
 
 namespace GAME
 {
@@ -44,7 +44,7 @@ namespace GAME
      * \param controller The game controller which is used (for controller mapping).
      * \param dllStruct The emulator or game to which the events are sent.
      */
-    CGameClientInput(CGameClient* addon, int port, const ControllerPtr& controller, const GameClient* dllStruct);
+    CGameClientInput(CGameClient* addon, int port, const ControllerPtr& controller, const KodiToAddonFuncTable_Game* dllStruct);
 
     // Implementation of IInputHandler
     virtual std::string ControllerID(void) const override;
@@ -63,6 +63,6 @@ namespace GAME
     const CGameClient* const  m_gameClient;
     const int                 m_port;
     const ControllerPtr       m_controller;
-    const GameClient* const   m_dllStruct;
+    const KodiToAddonFuncTable_Game* const m_dllStruct;
   };
 }

--- a/xbmc/games/addons/GameClientKeyboard.cpp
+++ b/xbmc/games/addons/GameClientKeyboard.cpp
@@ -30,7 +30,7 @@ using namespace GAME;
 
 #define BUTTON_INDEX_MASK  0x01ff
 
-CGameClientKeyboard::CGameClientKeyboard(const CGameClient* gameClient, const GameClient* dllStruct) :
+CGameClientKeyboard::CGameClientKeyboard(const CGameClient* gameClient, const KodiToAddonFuncTable_Game* dllStruct) :
   m_gameClient(gameClient),
   m_dllStruct(dllStruct)
 {

--- a/xbmc/games/addons/GameClientKeyboard.h
+++ b/xbmc/games/addons/GameClientKeyboard.h
@@ -21,7 +21,7 @@
 
 #include "input/keyboard/IKeyboardHandler.h"
 
-struct GameClient;
+struct KodiToAddonFuncTable_Game;
 
 namespace GAME
 {
@@ -41,7 +41,7 @@ namespace GAME
      * \param gameClient The game client implementation.
      * \param dllStruct The emulator or game to which the events are sent.
      */
-    CGameClientKeyboard(const CGameClient* gameClient, const GameClient* dllStruct);
+    CGameClientKeyboard(const CGameClient* gameClient, const KodiToAddonFuncTable_Game* dllStruct);
 
     /*!
      * \brief Destructor unregisters from keyboard events from CInputManager.
@@ -55,6 +55,6 @@ namespace GAME
   private:
     // Construction parameters
     const CGameClient* const m_gameClient;
-    const GameClient* const m_dllStruct;
+    const KodiToAddonFuncTable_Game* const m_dllStruct;
   };
 }

--- a/xbmc/games/addons/GameClientMouse.cpp
+++ b/xbmc/games/addons/GameClientMouse.cpp
@@ -28,7 +28,7 @@
 
 using namespace GAME;
 
-CGameClientMouse::CGameClientMouse(const CGameClient* gameClient, const GameClient* dllStruct) :
+CGameClientMouse::CGameClientMouse(const CGameClient* gameClient, const KodiToAddonFuncTable_Game* dllStruct) :
   m_gameClient(gameClient),
   m_dllStruct(dllStruct),
   m_controllerId(CInputManager::GetInstance().RegisterMouseHandler(this))

--- a/xbmc/games/addons/GameClientMouse.h
+++ b/xbmc/games/addons/GameClientMouse.h
@@ -21,7 +21,7 @@
 
 #include "input/mouse/IMouseInputHandler.h"
 
-struct GameClient;
+struct KodiToAddonFuncTable_Game;
 
 namespace GAME
 {
@@ -41,7 +41,7 @@ namespace GAME
      * \param gameClient The game client implementation.
      * \param dllStruct The emulator or game to which the events are sent.
      */
-    CGameClientMouse(const CGameClient* gameClient, const GameClient* dllStruct);
+    CGameClientMouse(const CGameClient* gameClient, const KodiToAddonFuncTable_Game* dllStruct);
 
     /*!
      * \brief Destructor unregisters from mouse events from CInputManager.
@@ -57,7 +57,7 @@ namespace GAME
   private:
     // Construction parameters
     const CGameClient* const m_gameClient;
-    const GameClient* const m_dllStruct;
+    const KodiToAddonFuncTable_Game* const m_dllStruct;
     const std::string m_controllerId;
   };
 }

--- a/xbmc/peripherals/addons/PeripheralAddon.h
+++ b/xbmc/peripherals/addons/PeripheralAddon.h
@@ -156,6 +156,6 @@ namespace PERIPHERALS
     CCriticalSection    m_critSection;
     
     PERIPHERAL_PROPERTIES m_info;
-    PeripheralAddon m_struct;
+    KodiToAddonFuncTable_Peripheral m_struct;
   };
 }


### PR DESCRIPTION
This also a small part of the rework, has hold it small now to ask that it is correct.

The struct `PVRClient` is renamed to `sKodiToAddonFuncTable_PVRClient`.

Goal of them is to have the begin text on every add-on type by the same. The other is that on rework the callbacks becomes placed on a other place.

On End comes it like this:
```cpp
  typedef struct sFuncTable_PVRClient
  {
    PVR_PROPERTIES props;
    sAddonToKodiFuncTable_PVRClient toKodi;
    sKodiToAddonFuncTable_PVRClient toAddon;
  } sFuncTable_PVRClient;
```

@FernetMenta is the name `sKodiToAddonFuncTable_PVRClient` OK for you? Has wanted it detailed, but is a bit long.