### PR TITLE
FFmpegPicture: Transition direct access of codec to codecpar

### DIFF
--- a/xbmc/guilib/FFmpegImage.h
+++ b/xbmc/guilib/FFmpegImage.h
@@ -61,6 +61,7 @@ struct MemBuffer
 struct AVFrame;
 struct AVIOContext;
 struct AVFormatContext;
+struct AVCodecContext;
 
 class CFFmpegImage : public IImage
 {
@@ -97,6 +98,7 @@ private:
 
   AVIOContext* m_ioctx = nullptr;
   AVFormatContext* m_fctx = nullptr;
+  AVCodecContext* m_codec_ctx = nullptr;
 
   AVFrame* m_pFrame;
   uint8_t* m_outputBuffer;


### PR DESCRIPTION
This is the first part (the more or less easy one) to the the codecpar transition.

Before: We used the stream's own codec_ctx that we opened and closed
Now: We use a member in combination with avcodec_parameters_to_context

I am not yet fully familiar with the way ffmpeg is now working. Happy for comments. It's tested and working.