### PR TITLE
FFmpegImage: Deprecate avcodec_encode_video2 and avcodec_decode_video2

### DIFF
--- a/xbmc/guilib/FFmpegImage.h
+++ b/xbmc/guilib/FFmpegImage.h
@@ -62,6 +62,7 @@ struct AVFrame;
 struct AVIOContext;
 struct AVFormatContext;
 struct AVCodecContext;
+struct AVPacket;
 
 class CFFmpegImage : public IImage
 {
@@ -88,6 +89,8 @@ private:
   static void FreeIOCtx(AVIOContext** ioctx);
   AVFrame* ExtractFrame();
   bool DecodeFrame(AVFrame* m_pFrame, unsigned int width, unsigned int height, unsigned int pitch, unsigned char * const pixels);
+  static int EncodeFFmpegFrame(AVCodecContext *avctx, AVPacket *pkt, int *got_packet, AVFrame *frame);
+  static int DecodeFFmpegFrame(AVCodecContext *avctx, AVFrame *frame, int *got_frame, AVPacket *pkt);
   static AVPixelFormat ConvertFormats(AVFrame* frame);
   std::string m_strMimeType;
   void CleanupLocalOutputBuffer();

--- a/xbmc/guilib/FFmpegImage.h
+++ b/xbmc/guilib/FFmpegImage.h
@@ -97,7 +97,6 @@ private:
 
 
   MemBuffer m_buf;
-  uint32_t m_frames = 0;
 
   AVIOContext* m_ioctx = nullptr;
   AVFormatContext* m_fctx = nullptr;


### PR DESCRIPTION
This is the "easy transition" for the avcodec_encode_video2 and avcodec_decode_video2

Btw. would it make sense to add those as static method into a util class?

Also one question: I have nothing to send if I get the EAGAIN any tipp on that?

Tested and working.

Edit: Very good documentation: https://blogs.gentoo.org/lu_zero/2016/03/29/new-avcodec-api/