### PR TITLE
[addons] remove dead code on CAddonDll

### DIFF
--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -70,8 +70,6 @@ namespace ADDON
     static bool AddOnGetSetting(void *userData, const char *settingName, void *settingValue);
     static void AddOnOpenSettings(const char *url, bool bReload);
     static void AddOnOpenOwnSettings(void *userData, bool bReload);
-    static const char* AddOnGetAddonDirectory(void *userData);
-    static const char* AddOnGetUserDirectory(void *userData);
   };
 
 }; /* namespace ADDON */


### PR DESCRIPTION
Removes two include functions from CAddonDll who not present.