### PR TITLE
FFmpegPicture: Adapt to new avcodec_receive_packet behaviour

### DIFF
--- a/xbmc/guilib/FFmpegImage.cpp
+++ b/xbmc/guilib/FFmpegImage.cpp
@@ -335,12 +335,9 @@ AVFrame* CFFmpegImage::ExtractFrame()
         m_orientation = (unsigned int)orientation;
     }
   }
-
-  AVFrame* clone = av_frame_clone(frame);
-  av_frame_free(&frame);
   av_packet_unref(&pkt);
 
-  return clone;
+  return frame;
 }
 
 AVPixelFormat CFFmpegImage::ConvertFormats(AVFrame* frame)


### PR DESCRIPTION
This fixes encoding of images. With the new API the resulting AVPacket is allocated by the encoder. That means it does not use our memory anymore, see: https://ffmpeg.org/doxygen/trunk/group__lavc__decoding.html#ga5b8eff59cf259747cf0b31563e38ded6

~Do you see a way arround having to copy the memory?~