### PR TITLE
[addons] remove 'Stop()' from binary add-on interface

### DIFF
--- a/xbmc/addons/AddonDll.cpp
+++ b/xbmc/addons/AddonDll.cpp
@@ -226,15 +226,6 @@ ADDON_STATUS CAddonDll::Create(void* funcTable, void* info)
   return status;
 }
 
-void CAddonDll::Stop()
-{
-  if (m_pDll)
-  {
-    m_pDll->Stop();
-    CLog::Log(LOGINFO, "ADDON: Dll Stopped - %s", Name().c_str());
-  }
-}
-
 void CAddonDll::Destroy()
 {
   if (m_pDll)

--- a/xbmc/addons/AddonDll.cpp
+++ b/xbmc/addons/AddonDll.cpp
@@ -228,25 +228,6 @@ ADDON_STATUS CAddonDll::Create(void* funcTable, void* info)
 
 void CAddonDll::Stop()
 {
-  /* Inform dll to stop all activities */
-  if (m_needsavedsettings)  // If the addon supports it we save some settings to settings.xml before stop
-  {
-    char   str_id[64] = "";
-    char   str_value[1024];
-    CAddon::LoadUserSettings();
-    for (unsigned int i=0; (strcmp(str_id,"###End") != 0); i++)
-    {
-      strcpy(str_id, "###GetSavedSettings");
-      sprintf (str_value, "%i", i);
-      ADDON_STATUS status = m_pDll->SetSetting((const char*)&str_id, (void*)&str_value);
-
-      if (status == ADDON_STATUS_UNKNOWN)
-        break;
-
-      if (strcmp(str_id,"###End") != 0) UpdateSetting(str_id, str_value);
-    }
-    CAddon::SaveSettings();
-  }
   if (m_pDll)
   {
     m_pDll->Stop();
@@ -256,9 +237,28 @@ void CAddonDll::Stop()
 
 void CAddonDll::Destroy()
 {
-  /* Unload library file */
   if (m_pDll)
   {
+    /* Inform dll to stop all activities */
+    if (m_needsavedsettings)  // If the addon supports it we save some settings to settings.xml before stop
+    {
+      char   str_id[64] = "";
+      char   str_value[1024];
+      CAddon::LoadUserSettings();
+      for (unsigned int i=0; (strcmp(str_id,"###End") != 0); i++)
+      {
+        strcpy(str_id, "###GetSavedSettings");
+        sprintf (str_value, "%i", i);
+        ADDON_STATUS status = m_pDll->SetSetting((const char*)&str_id, (void*)&str_value);
+
+        if (status == ADDON_STATUS_UNKNOWN)
+          break;
+
+        if (strcmp(str_id,"###End") != 0) UpdateSetting(str_id, str_value);
+      }
+      CAddon::SaveSettings();
+    }
+    /* Unload library file */
     m_pDll->Destroy();
     m_pDll->Unload();
   }

--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -42,7 +42,6 @@ namespace ADDON
     virtual std::string GetSetting(const std::string& key);
 
     ADDON_STATUS Create(void* funcTable, void* info);
-    virtual void Stop();
     virtual bool CheckAPIVersion(void) { return true; }
     void Destroy();
 

--- a/xbmc/addons/DllAddon.h
+++ b/xbmc/addons/DllAddon.h
@@ -28,7 +28,6 @@ public:
   virtual ~DllAddonInterface() {}
   virtual void GetAddon(void* pAddon) =0;
   virtual ADDON_STATUS Create(void *cb, void *info) =0;
-  virtual void Stop() =0;
   virtual void Destroy() =0;
   virtual ADDON_STATUS GetStatus() =0;
   virtual bool HasSettings() =0;
@@ -42,7 +41,6 @@ class DllAddon : public DllDynamic, public DllAddonInterface
 public:
   DECLARE_DLL_WRAPPER_TEMPLATE(DllAddon)
   DEFINE_METHOD2(ADDON_STATUS, Create, (void* p1, void* p2))
-  DEFINE_METHOD0(void, Stop)
   DEFINE_METHOD0(void, Destroy)
   DEFINE_METHOD0(ADDON_STATUS, GetStatus)
   DEFINE_METHOD0(bool, HasSettings)
@@ -53,7 +51,6 @@ public:
   BEGIN_METHOD_RESOLVE()
     RESOLVE_METHOD_RENAME(get_addon,GetAddon)
     RESOLVE_METHOD_RENAME(ADDON_Create, Create)
-    RESOLVE_METHOD_RENAME(ADDON_Stop, Stop)
     RESOLVE_METHOD_RENAME(ADDON_Destroy, Destroy)
     RESOLVE_METHOD_RENAME(ADDON_GetStatus, GetStatus)
     RESOLVE_METHOD_RENAME(ADDON_HasSettings, HasSettings)

--- a/xbmc/addons/ScreenSaver.cpp
+++ b/xbmc/addons/ScreenSaver.cpp
@@ -88,6 +88,12 @@ void CScreenSaver::Start()
   if (Initialized()) m_struct.Start();
 }
 
+void CScreenSaver::Stop()
+{
+  // notify screen saver that they should start
+  if (Initialized()) m_struct.Stop();
+}
+
 void CScreenSaver::Render()
 {
   // ask screensaver to render itself

--- a/xbmc/addons/ScreenSaver.h
+++ b/xbmc/addons/ScreenSaver.h
@@ -37,6 +37,7 @@ public:
   // Things that MUST be supplied by the child classes
   bool CreateScreenSaver();
   void Start();
+  void Stop();
   void Render();
   void Destroy();
 

--- a/xbmc/addons/Visualisation.cpp
+++ b/xbmc/addons/Visualisation.cpp
@@ -146,7 +146,7 @@ void CVisualisation::Stop()
   CServiceBroker::GetActiveAE().UnregisterAudioCallback(this);
   if (Initialized())
   {
-    CAddonDll::Stop();
+    m_struct.Stop();
   }
 }
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_scr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_scr_dll.h
@@ -28,6 +28,7 @@ extern "C"
 
   // Functions that your visualisation must implement
   void Start();
+  void Stop();
   void Render();
 
   // function to export the above structure to XBMC
@@ -36,6 +37,7 @@ extern "C"
     KodiToAddonFuncTable_Screensaver* pScr = static_cast<KodiToAddonFuncTable_Screensaver*>(ptr);
 
     pScr->Start = Start;
+    pScr->Stop = Stop;
     pScr->Render = Render;
   };
 };

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_scr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_scr_types.h
@@ -38,6 +38,7 @@ extern "C"
   typedef struct KodiToAddonFuncTable_Screensaver
   {
     void (__cdecl* Start) ();
+    void (__cdecl* Stop) ();
     void (__cdecl* Render) ();
   } KodiToAddonFuncTable_Screensaver;
 }

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_vis_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_vis_dll.h
@@ -27,6 +27,7 @@ extern "C"
 {
   // Functions that your visualisation must implement
   void Start(int iChannels, int iSamplesPerSec, int iBitsPerSample, const char* szSongName);
+  void Stop();
   void AudioData(const float* pAudioData, int iAudioDataLength, float *pFreqData, int iFreqDataLength);
   void Render();
   bool OnAction(long action, const void *param);
@@ -42,6 +43,7 @@ extern "C"
     KodiToAddonFuncTable_Visualisation* pVisz = static_cast<KodiToAddonFuncTable_Visualisation*>(ptr);
 
     pVisz->Start = Start;
+    pVisz->Stop = Stop;
     pVisz->AudioData = AudioData;
     pVisz->Render = Render;
     pVisz->OnAction = OnAction;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_vis_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_vis_types.h
@@ -96,6 +96,7 @@ extern "C"
   typedef struct KodiToAddonFuncTable_Visualisation
   {
     void (__cdecl* Start)(int iChannels, int iSamplesPerSec, int iBitsPerSample, const char* szSongName);
+    void (__cdecl* Stop)();
     void (__cdecl* AudioData)(const float* pAudioData, int iAudioDataLength, float *pFreqData, int iFreqDataLength);
     void (__cdecl* Render) ();
     void (__cdecl* GetInfo)(VIS_INFO *info);

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -31,7 +31,6 @@ CInputStreamAddon::CInputStreamAddon(const CFileItem& fileitem, std::shared_ptr<
 CInputStreamAddon::~CInputStreamAddon()
 {
   Close();
-  m_addon->Stop();
   m_addon.reset();
 }
 


### PR DESCRIPTION
The Stop() function was nearly never needed, also match this not the multiple instance way, further was also never a equivalent with "Start()" present.

For this reasons becomes it removed.