### PR TITLE
[addons] standardize GetCapabilities add-on functions

### DIFF
--- a/addons/kodi.adsp/addon.xml
+++ b/addons/kodi.adsp/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.adsp" version="0.1.9" provider-name="Team KODI">
+<addon id="kodi.adsp" version="0.1.10" provider-name="Team KODI">
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>

--- a/addons/kodi.inputstream/addon.xml
+++ b/addons/kodi.inputstream/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.inputstream" version="1.0.7" provider-name="Team Kodi">
+<addon id="kodi.inputstream" version="1.0.8" provider-name="Team Kodi">
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>

--- a/addons/kodi.peripheral/addon.xml
+++ b/addons/kodi.peripheral/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.peripheral" version="1.2.1" provider-name="Team-Kodi">
+<addon id="kodi.peripheral" version="1.2.3" provider-name="Team-Kodi">
 	<requires>
 		<import addon="xbmc.core" version="0.1.0"/>
 	</requires>

--- a/addons/xbmc.pvr/addon.xml
+++ b/addons/xbmc.pvr/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="xbmc.pvr" version="5.2.2" provider-name="Team-Kodi">
+<addon id="xbmc.pvr" version="5.2.3" provider-name="Team-Kodi">
   <requires>
     <import addon="xbmc.core" version="0.1.0"/>
   </requires>

--- a/xbmc/addons/InputStream.cpp
+++ b/xbmc/addons/InputStream.cpp
@@ -229,7 +229,10 @@ bool CInputStream::Open(CFileItem &fileitem)
 
   bool ret = m_struct.Open(props);
   if (ret)
-    m_caps = m_struct.GetCapabilities();
+  {
+    memset(&m_caps, 0, sizeof(m_caps));
+    m_struct.GetCapabilities(&m_caps);
+  }
 
   UpdateStreams();
   return ret;

--- a/xbmc/addons/PVRClient.cpp
+++ b/xbmc/addons/PVRClient.cpp
@@ -364,12 +364,7 @@ bool CPVRClient::GetAddonProperties(void)
 
   /* get the capabilities */
   memset(&addonCapabilities, 0, sizeof(addonCapabilities));
-  PVR_ERROR retVal = m_struct.GetAddonCapabilities(&addonCapabilities);
-  if (retVal != PVR_ERROR_NO_ERROR)
-  {
-    CLog::Log(LOGERROR, "PVR - couldn't get the capabilities for add-on '%s'. Please contact the developer of this add-on: %s", GetFriendlyName().c_str(), Author().c_str());
-    return false;
-  }
+  m_struct.GetCapabilities(&addonCapabilities);
 
   /* get the name of the backend */
   strBackendName = m_struct.GetBackendName();

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_adsp_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_adsp_dll.h
@@ -30,7 +30,7 @@
  * @subsection sec1_1 General
  * @li The basic support on the addon is supplied with the
  * AE_DSP_ADDON_CAPABILITIES data which becomes asked over
- * GetAddonCapabilities(...), further the addon must register his available
+ * GetCapabilities(...), further the addon must register his available
  * modes on startup with the RegisterMode(...) callback function (see
  * libKODI_adsp.h). If one of this two points is not set the addon becomes
  * ignored for the chain step.
@@ -103,10 +103,9 @@ extern "C"
    * to call, etc.
    * All capabilities that the add-on supports should be set to true.
    * @param pCapabilities The add-ons capabilities.
-   * @return AE_DSP_ERROR_NO_ERROR if the properties were fetched successfully.
    * @remarks Valid implementation required.
    */
-  AE_DSP_ERROR GetAddonCapabilities(AE_DSP_ADDON_CAPABILITIES *pCapabilities);
+  void GetCapabilities(AE_DSP_ADDON_CAPABILITIES *pCapabilities);
 
   /*!
    * @return The name reported by the back end that will be displayed in the
@@ -202,7 +201,7 @@ extern "C"
    * @param samples Amount of samples inside array_in
    * @return true if work was OK
    * @remarks Optional. Is set by AE_DSP_ADDON_CAPABILITIES and asked with
-   * GetAddonCapabilities
+   * GetCapabilities
    */
   bool InputProcess(const ADDON_HANDLE handle, const float **array_in, unsigned int samples);
   //@}
@@ -218,7 +217,7 @@ extern "C"
    * @param handle identification data for stream
    * @return The needed size of output array or 0 if no changes within it
    * @remarks Optional. Is set by AE_DSP_ADDON_CAPABILITIES and asked with
-   * GetAddonCapabilities
+   * GetCapabilities
    */
   unsigned int InputResampleProcessNeededSamplesize(const ADDON_HANDLE handle);
 
@@ -232,7 +231,7 @@ extern "C"
    * @param samples Amount of samples inside array_in
    * @return Amount of samples processed
    * @remarks Optional. Is set by AE_DSP_ADDON_CAPABILITIES and asked with
-   * GetAddonCapabilities
+   * GetCapabilities
    */
   unsigned int InputResampleProcess(const ADDON_HANDLE handle, float **array_in, float **array_out, unsigned int samples);
 
@@ -242,7 +241,7 @@ extern "C"
    * @param handle identification data for stream
    * @return The new sample rate
    * @remarks Optional. Is set by AE_DSP_ADDON_CAPABILITIES and asked with
-   * GetAddonCapabilities
+   * GetCapabilities
    */
   int InputResampleSampleRate(const ADDON_HANDLE handle);
 
@@ -252,7 +251,7 @@ extern "C"
    * @param handle identification data for stream
    * @return the delay in seconds
    * @remarks Optional. Is set by AE_DSP_ADDON_CAPABILITIES and asked with
-   * GetAddonCapabilities
+   * GetCapabilities
    */
   float InputResampleGetDelay(const ADDON_HANDLE handle);
   //@}
@@ -272,7 +271,7 @@ extern "C"
    * pointer or anything else what is needed to find it.
    * @return The needed size of output array or 0 if no changes within it
    * @remarks Optional. Is set by AE_DSP_ADDON_CAPABILITIES and asked with
-   * GetAddonCapabilities
+   * GetCapabilities
    */
   unsigned int PreProcessNeededSamplesize(const ADDON_HANDLE handle, unsigned int mode_id);
 
@@ -286,7 +285,7 @@ extern "C"
    * pointer or anything else what is needed to find it.
    * @return the delay in seconds
    * @remarks Optional. Is set by AE_DSP_ADDON_CAPABILITIES and asked with
-   * GetAddonCapabilities
+   * GetCapabilities
    */
   float PreProcessGetDelay(const ADDON_HANDLE handle, unsigned int mode_id);
 
@@ -303,7 +302,7 @@ extern "C"
    * @param samples Amount of samples inside array_in
    * @return Amount of samples processed
    * @remarks Optional. Is set by AE_DSP_ADDON_CAPABILITIES and asked with
-   * GetAddonCapabilities
+   * GetCapabilities
    */
   unsigned int PreProcess(const ADDON_HANDLE handle, unsigned int mode_id, float **array_in, float **array_out, unsigned int samples);
   //@}
@@ -320,7 +319,7 @@ extern "C"
    * @param unique_db_mode_id The Mode unique id generated from DSP database.
    * @return AE_DSP_ERROR_NO_ERROR if the setup was successful
    * @remarks Optional. Is set by AE_DSP_ADDON_CAPABILITIES and asked with
-   * GetAddonCapabilities
+   * GetCapabilities
    */
   AE_DSP_ERROR MasterProcessSetMode(const ADDON_HANDLE handle, AE_DSP_STREAMTYPE type, unsigned int mode_id, int unique_db_mode_id);
 
@@ -331,7 +330,7 @@ extern "C"
    * @param handle identification data for stream
    * @return The needed size of output array or 0 if no changes within it
    * @remarks Optional. Is set by AE_DSP_ADDON_CAPABILITIES and asked with
-   * GetAddonCapabilities
+   * GetCapabilities
    */
   unsigned int MasterProcessNeededSamplesize(const ADDON_HANDLE handle);
 
@@ -341,7 +340,7 @@ extern "C"
    * @param handle identification data for stream
    * @return the delay in seconds
    * @remarks Optional. Is set by AE_DSP_ADDON_CAPABILITIES and asked with
-   * GetAddonCapabilities
+   * GetCapabilities
    */
   float MasterProcessGetDelay(const ADDON_HANDLE handle);
 
@@ -366,7 +365,7 @@ extern "C"
    * @param samples Amount of samples inside array_in
    * @return Amount of samples processed
    * @remarks Optional. Is set by AE_DSP_ADDON_CAPABILITIES and asked with
-   * GetAddonCapabilities
+   * GetCapabilities
    */
   unsigned int MasterProcess(const ADDON_HANDLE handle, float **array_in, float **array_out, unsigned int samples);
 
@@ -374,7 +373,7 @@ extern "C"
    * Used to get a information string about the processed work to show on skin
    * @return A string to show
    * @remarks Optional. Is set by AE_DSP_ADDON_CAPABILITIES and asked with
-   * GetAddonCapabilities
+   * GetCapabilities
    */
   const char *MasterProcessGetStreamInfoString(const ADDON_HANDLE handle);
   //@}
@@ -394,7 +393,7 @@ extern "C"
    * pointer or anything else what is needed to find it.
    * @return The needed size of output array or 0 if no changes within it
    * @remarks Optional. Is set by AE_DSP_ADDON_CAPABILITIES and asked with
-   * GetAddonCapabilities
+   * GetCapabilities
    */
   unsigned int PostProcessNeededSamplesize(const ADDON_HANDLE handle, unsigned int mode_id);
 
@@ -408,7 +407,7 @@ extern "C"
    * pointer or anything else what is needed to find it.
    * @return the delay in seconds
    * @remarks Optional. Is set by AE_DSP_ADDON_CAPABILITIES and asked with
-   * GetAddonCapabilities
+   * GetCapabilities
    */
   float PostProcessGetDelay(const ADDON_HANDLE handle, unsigned int mode_id);
 
@@ -428,7 +427,7 @@ extern "C"
    * @param samples Amount of samples inside array_in
    * @return Amount of samples processed
    * @remarks Optional. Is set by AE_DSP_ADDON_CAPABILITIES and asked with
-   * GetAddonCapabilities
+   * GetCapabilities
    */
   unsigned int PostProcess(const ADDON_HANDLE handle, unsigned int mode_id, float **array_in, float **array_out, unsigned int samples);
   //@}
@@ -444,7 +443,7 @@ extern "C"
    * @param handle identification data for stream
    * @return The needed size of output array or 0 if no changes within it
    * @remarks Optional. Is set by AE_DSP_ADDON_CAPABILITIES and asked with
-   * GetAddonCapabilities
+   * GetCapabilities
    */
   unsigned int OutputResampleProcessNeededSamplesize(const ADDON_HANDLE handle);
 
@@ -458,7 +457,7 @@ extern "C"
    * @param samples Amount of samples inside array_in
    * @return Amount of samples processed
    * @remarks Optional. Is set by AE_DSP_ADDON_CAPABILITIES and asked with
-   * GetAddonCapabilities
+   * GetCapabilities
    */
   unsigned int OutputResampleProcess(const ADDON_HANDLE handle, float **array_in, float **array_out, unsigned int samples);
 
@@ -468,7 +467,7 @@ extern "C"
    * @param handle identification data for stream
    * @return The new sample rate
    * @remarks Optional. Is set by AE_DSP_ADDON_CAPABILITIES and asked with
-   * GetAddonCapabilities
+   * GetCapabilities
    */
   int OutputResampleSampleRate(const ADDON_HANDLE handle);
 
@@ -478,7 +477,7 @@ extern "C"
    * @param handle identification data for stream
    * @return the delay in seconds
    * @remarks Optional. Is set by AE_DSP_ADDON_CAPABILITIES and asked with
-   * GetAddonCapabilities
+   * GetCapabilities
    */
   float OutputResampleGetDelay(const ADDON_HANDLE handle);
   //@}
@@ -488,7 +487,7 @@ extern "C"
   {
     KodiToAddonFuncTable_AudioDSP* pDSP = static_cast<KodiToAddonFuncTable_AudioDSP*>(ptr);
 
-    pDSP->GetAddonCapabilities                  = GetAddonCapabilities;
+    pDSP->GetCapabilities = GetCapabilities;
     pDSP->GetDSPName                            = GetDSPName;
     pDSP->GetDSPVersion                         = GetDSPVersion;
     pDSP->MenuHook                              = CallMenuHook;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_adsp_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_adsp_types.h
@@ -469,7 +469,7 @@ extern "C" {
    */
   typedef struct KodiToAddonFuncTable_AudioDSP
   {
-    AE_DSP_ERROR (__cdecl* GetAddonCapabilities)                 (AE_DSP_ADDON_CAPABILITIES*);
+    void (__cdecl* GetCapabilities)(AE_DSP_ADDON_CAPABILITIES*);
     const char*  (__cdecl* GetDSPName)                           (void);
     const char*  (__cdecl* GetDSPVersion)                        (void);
     AE_DSP_ERROR (__cdecl* MenuHook)                             (const AE_DSP_MENUHOOK&, const AE_DSP_MENUHOOK_DATA&);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_dll.h
@@ -53,9 +53,10 @@ extern "C"
 
   /*!
   * Get Capabilities of this addon.
+  * @param pCapabilities The add-on's capabilities.
   * @remarks
   */
-  struct INPUTSTREAM_CAPABILITIES GetCapabilities();
+  void GetCapabilities(INPUTSTREAM_CAPABILITIES *pCapabilities);
 
 
   /*!

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_types.h
@@ -126,7 +126,7 @@ extern "C" {
     bool (__cdecl* Open)(INPUTSTREAM&);
     void (__cdecl* Close)(void);
     const char* (__cdecl* GetPathList)(void);
-    struct INPUTSTREAM_CAPABILITIES (__cdecl* GetCapabilities)(void);
+    void (__cdecl* GetCapabilities)(INPUTSTREAM_CAPABILITIES*);
 
     // IDemux
     struct INPUTSTREAM_IDS (__cdecl* GetStreamIds)();

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_dll.h
@@ -34,14 +34,13 @@ extern "C"
   /*!
    * @brief Get the list of features that this add-on provides
    * @param pCapabilities The add-on's capabilities.
-   * @return PERIPHERAL_NO_ERROR if the properties were fetched successfully.
    * @remarks Valid implementation required.
    *
    * Called by the frontend to query the add-on's capabilities and supported
    * peripherals. All capabilities that the add-on supports should be set to true.
    *
    */
-  PERIPHERAL_ERROR GetAddonCapabilities(PERIPHERAL_CAPABILITIES *pCapabilities);
+  void GetCapabilities(PERIPHERAL_CAPABILITIES *pCapabilities);
 
   /*!
    * @brief Perform a scan for joysticks
@@ -216,7 +215,7 @@ extern "C"
   {
     KodiToAddonFuncTable_Peripheral* pClient = static_cast<KodiToAddonFuncTable_Peripheral*>(ptr);
 
-    pClient->GetAddonCapabilities           = GetAddonCapabilities;
+    pClient->GetCapabilities = GetCapabilities;
     pClient->PerformDeviceScan              = PerformDeviceScan;
     pClient->FreeScanResults                = FreeScanResults;
     pClient->GetEvents                      = GetEvents;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_peripheral_types.h
@@ -284,7 +284,7 @@ extern "C"
    */
   typedef struct KodiToAddonFuncTable_Peripheral
   {
-    PERIPHERAL_ERROR (__cdecl* GetAddonCapabilities)(PERIPHERAL_CAPABILITIES*);
+    void (__cdecl* GetCapabilities)(PERIPHERAL_CAPABILITIES*);
     PERIPHERAL_ERROR (__cdecl* PerformDeviceScan)(unsigned int*, PERIPHERAL_INFO**);
     void             (__cdecl* FreeScanResults)(unsigned int, PERIPHERAL_INFO*);
     PERIPHERAL_ERROR (__cdecl* GetEvents)(unsigned int*, PERIPHERAL_EVENT**);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -45,7 +45,7 @@
 #define INSTANCE_VERSION_GAME                   "1.0.29"
 #define INSTANCE_VERSION_INPUTSTREAM            "1.0.7"
 #define INSTANCE_VERSION_PERIPHERAL             "1.2.2"
-#define INSTANCE_VERSION_PVR                    "5.2.2"
+#define INSTANCE_VERSION_PVR                    "5.2.3"
 #define INSTANCE_VERSION_SCREENSAVER            "1.0.1"
 #define INSTANCE_VERSION_VISUALIZATION          "1.0.1"
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -39,7 +39,7 @@
 #define GLOBAL_VERSION_MAIN                     "1.0.0"
 #define GLOBAL_VERSION_GUI                      "5.11.1"
 
-#define INSTANCE_VERSION_ADSP                   "0.1.9"
+#define INSTANCE_VERSION_ADSP                   "0.1.10"
 #define INSTANCE_VERSION_AUDIODECODER           "1.0.1"
 #define INSTANCE_VERSION_AUDIOENCODER           "1.0.1"
 #define INSTANCE_VERSION_GAME                   "1.0.29"

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -44,7 +44,7 @@
 #define INSTANCE_VERSION_AUDIOENCODER           "1.0.1"
 #define INSTANCE_VERSION_GAME                   "1.0.29"
 #define INSTANCE_VERSION_INPUTSTREAM            "1.0.8"
-#define INSTANCE_VERSION_PERIPHERAL             "1.2.2"
+#define INSTANCE_VERSION_PERIPHERAL             "1.2.3"
 #define INSTANCE_VERSION_PVR                    "5.2.3"
 #define INSTANCE_VERSION_SCREENSAVER            "1.0.1"
 #define INSTANCE_VERSION_VISUALIZATION          "1.0.1"

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -43,7 +43,7 @@
 #define INSTANCE_VERSION_AUDIODECODER           "1.0.1"
 #define INSTANCE_VERSION_AUDIOENCODER           "1.0.1"
 #define INSTANCE_VERSION_GAME                   "1.0.29"
-#define INSTANCE_VERSION_INPUTSTREAM            "1.0.7"
+#define INSTANCE_VERSION_INPUTSTREAM            "1.0.8"
 #define INSTANCE_VERSION_PERIPHERAL             "1.2.2"
 #define INSTANCE_VERSION_PVR                    "5.2.3"
 #define INSTANCE_VERSION_SCREENSAVER            "1.0.1"

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_dll.h
@@ -39,10 +39,9 @@ extern "C"
    * Used to check which options should be presented in the UI, which methods to call, etc.
    * All capabilities that the add-on supports should be set to true.
    * @param pCapabilities The add-on's capabilities.
-   * @return PVR_ERROR_NO_ERROR if the properties were fetched successfully.
    * @remarks Valid implementation required.
    */
-  PVR_ERROR GetAddonCapabilities(PVR_ADDON_CAPABILITIES *pCapabilities);
+  void GetCapabilities(PVR_ADDON_CAPABILITIES *pCapabilities);
 
   /*!
    * @return The name reported by the backend that will be displayed in the UI.
@@ -629,7 +628,7 @@ extern "C"
   {
     KodiToAddonFuncTable_PVR* pClient = static_cast<KodiToAddonFuncTable_PVR*>(ptr);
     
-    pClient->GetAddonCapabilities           = GetAddonCapabilities;
+    pClient->GetCapabilities = GetCapabilities;
     pClient->GetStreamProperties            = GetStreamProperties;
     pClient->GetConnectionString            = GetConnectionString;
     pClient->GetBackendName                 = GetBackendName;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_pvr_types.h
@@ -547,7 +547,7 @@ extern "C" {
    */
   typedef struct KodiToAddonFuncTable_PVR
   {
-    PVR_ERROR    (__cdecl* GetAddonCapabilities)(PVR_ADDON_CAPABILITIES*);
+    void (__cdecl* GetCapabilities)(PVR_ADDON_CAPABILITIES*);
     PVR_ERROR    (__cdecl* GetStreamProperties)(PVR_STREAM_PROPERTIES*);
     const char*  (__cdecl* GetBackendName)(void);
     const char*  (__cdecl* GetBackendVersion)(void);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSPAddon.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSPAddon.cpp
@@ -180,12 +180,7 @@ bool CActiveAEDSPAddon::GetAddonProperties(void)
 
   /* get the capabilities */
   memset(&addonCapabilities, 0, sizeof(addonCapabilities));
-  AE_DSP_ERROR retVal = m_struct.GetAddonCapabilities(&addonCapabilities);
-  if (retVal != AE_DSP_ERROR_NO_ERROR)
-  {
-    CLog::Log(LOGERROR, "ActiveAE DSP - couldn't get the capabilities for add-on '%s'. Please contact the developer of this add-on: %s", GetFriendlyName().c_str(), Author().c_str());
-    return false;
-  }
+  m_struct.GetCapabilities(&addonCapabilities);
 
   /* get the name of the dsp addon */
   std::string strDSPName = m_struct.GetDSPName();

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSPAddon.h
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSPAddon.h
@@ -174,7 +174,7 @@ namespace ActiveAE
      * @param array_in Pointer to data memory
      * @param samples Amount of samples inside array_in
      * @return true if work was OK
-     * @remarks Optional. Is set by AE_DSP_ADDON_CAPABILITIES and asked with GetAddonCapabilities
+     * @remarks Optional. Is set by AE_DSP_ADDON_CAPABILITIES and asked with GetCapabilities
      */
     bool InputProcess(const ADDON_HANDLE handle, const float **array_in, unsigned int samples);
 

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -151,13 +151,7 @@ bool CPeripheralAddon::GetAddonProperties(void)
   PERIPHERAL_CAPABILITIES addonCapabilities = { };
 
   // Get the capabilities
-  PERIPHERAL_ERROR retVal = m_struct.GetAddonCapabilities(&addonCapabilities);
-  if (retVal != PERIPHERAL_NO_ERROR)
-  {
-    CLog::Log(LOGERROR, "PERIPHERAL - couldn't get the capabilities for add-on '%s'. Please contact the developer of this add-on: %s",
-        Name().c_str(), Author().c_str());
-    return false;
-  }
+  m_struct.GetCapabilities(&addonCapabilities);
 
   // Verify capabilities against addon.xml
   if (m_bProvidesJoysticks != addonCapabilities.provides_joysticks)


### PR DESCRIPTION
This standardize the GetCapabilities add-on functions on all add-on types where it is used to the same way.

Further is the return value where used before removed, has never seen a add-on who has returned something else as OK.