### PR TITLE
[addons] cleanup and improve changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,7 @@ endif()
 # Compile Info
 add_custom_command(OUTPUT ${CORE_BUILD_DIR}/xbmc/CompileInfo.cpp
                           ${CMAKE_BINARY_DIR}/addons/xbmc.addon/addon.xml
+                          ${CMAKE_BINARY_DIR}/addons/kodi.guilib/addon.xml
                    COMMAND ${CMAKE_COMMAND} -DCORE_SOURCE_DIR=${CMAKE_SOURCE_DIR}
                                             -DCORE_SYSTEM_NAME=${CORE_SYSTEM_NAME}
                                             -DCORE_BUILD_DIR=${CORE_BUILD_DIR}
@@ -243,9 +244,11 @@ add_custom_command(OUTPUT ${CORE_BUILD_DIR}/xbmc/CompileInfo.cpp
                                             -P ${CMAKE_SOURCE_DIR}/cmake/scripts/common/GenerateVersionedFiles.cmake
                    DEPENDS ${CMAKE_SOURCE_DIR}/version.txt
                            ${CMAKE_SOURCE_DIR}/addons/xbmc.addon/addon.xml.in
+                           ${CMAKE_SOURCE_DIR}/addons/kodi.guilib/addon.xml.in
                            ${CMAKE_SOURCE_DIR}/xbmc/CompileInfo.cpp.in)
 list(APPEND install_data addons/xbmc.addon/addon.xml)
 list(APPEND install_data addons/xbmc.json/addon.xml)
+list(APPEND install_data addons/kodi.guilib/addon.xml)
 add_library(compileinfo OBJECT ${CORE_BUILD_DIR}/xbmc/CompileInfo.cpp)
 set_target_properties(compileinfo PROPERTIES FOLDER "Build Utilities")
 target_compile_options(compileinfo PRIVATE "${SYSTEM_DEFINES}")

--- a/addons/kodi.guilib/addon.xml
+++ b/addons/kodi.guilib/addon.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.guilib" version="5.11.1" provider-name="Team-Kodi">
-  <requires>
-    <import addon="xbmc.core" version="0.1.0"/>
-  </requires>
-</addon>

--- a/addons/kodi.guilib/addon.xml.in
+++ b/addons/kodi.guilib/addon.xml.in
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<addon id="kodi.guilib" version="@guilib_version@" provider-name="Team-Kodi">
+  <backwards-compatibility abi="@guilib_version_min@"/>
+  <requires>
+    <import addon="xbmc.core" version="0.1.0"/>
+  </requires>
+</addon>

--- a/cmake/installdata/common/addons.txt
+++ b/cmake/installdata/common/addons.txt
@@ -6,7 +6,6 @@ addons/kodi.adsp/*
 addons/kodi.audiodecoder/*
 addons/kodi.audioencoder/*
 addons/kodi.game/*
-addons/kodi.guilib/*
 addons/kodi.inputstream/*
 addons/kodi.peripheral/*
 addons/kodi.pvr/*

--- a/cmake/scripts/common/GenerateVersionedFiles.cmake
+++ b/cmake/scripts/common/GenerateVersionedFiles.cmake
@@ -2,6 +2,7 @@ include(${CORE_SOURCE_DIR}/cmake/scripts/common/Macros.cmake)
 
 core_find_versions()
 file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/addons/xbmc.addon)
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/addons/kodi.guilib)
 
 # configure_file without dependency tracking
 # configure_file would register additional file dependencies that interfere
@@ -13,4 +14,5 @@ function(generate_versioned_file _SRC _DEST)
 endfunction()
 
 generate_versioned_file(addons/xbmc.addon/addon.xml.in addons/xbmc.addon/addon.xml)
+generate_versioned_file(addons/kodi.guilib/addon.xml.in addons/kodi.guilib/addon.xml)
 generate_versioned_file(xbmc/CompileInfo.cpp.in ${CORE_BUILD_DIR}/xbmc/CompileInfo.cpp)

--- a/cmake/scripts/common/Macros.cmake
+++ b/cmake/scripts/common/Macros.cmake
@@ -571,7 +571,7 @@ function(core_find_git_rev stamp)
   endif()
 endfunction()
 
-# Parses version.txt and sets variables
+# Parses version.txt and libKODI_guilib.h and sets variables
 # used to construct dirs structure, file naming, API version, etc.
 #
 # The following variables are set from version.txt:
@@ -586,6 +586,10 @@ endfunction()
 #   APP_VERSION - the app version (${APP_VERSION_MAJOR}.${APP_VERSION_MINOR}-${APP_VERSION_TAG})
 #   APP_ADDON_API - the addon API version in the form of 16.9.702
 #   FILE_VERSION - file version in the form of 16,9,702,0 - Windows only
+#
+# The following variables are set from libKODI_guilib.h:
+#   guilib_version - current ADDONGUI API version
+#   guilib_version_min - minimal ADDONGUI API version
 macro(core_find_versions)
   # kodi-addons project also calls this macro and uses CORE_SOURCE_DIR
   # to point to core base dir
@@ -611,6 +615,10 @@ macro(core_find_versions)
     string(TOLOWER ${APP_VERSION_TAG} APP_VERSION_TAG_LC)
   endif()
   string(REPLACE "." "," FILE_VERSION ${APP_ADDON_API}.0)
+  file(STRINGS ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_guilib.h guilib_version REGEX "^.*GUILIB_API_VERSION (.*)$")
+  string(REGEX REPLACE ".*\"(.*)\"" "\\1" guilib_version ${guilib_version})
+  file(STRINGS ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_guilib.h guilib_version_min REGEX "^.*GUILIB_MIN_API_VERSION (.*)$")
+  string(REGEX REPLACE ".*\"(.*)\"" "\\1" guilib_version_min ${guilib_version_min})
   # unset variables not used anywhere else
   unset(version_list)
   unset(APP_APP_NAME)
@@ -618,6 +626,11 @@ macro(core_find_versions)
   # bail if we can't parse version.txt
   if(NOT DEFINED APP_VERSION_MAJOR OR NOT DEFINED APP_VERSION_MINOR)
     message(FATAL_ERROR "Could not determine app version! Make sure that ${CORE_SOURCE_DIR}/version.txt exists")
+  endif()
+
+  # bail if we can't parse libKODI_guilib.h
+  if(NOT DEFINED guilib_version OR NOT DEFINED guilib_version_min)
+    message(FATAL_ERROR "Could not determine add-on API version! Make sure that ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_guilib.h exists")
   endif()
 endmacro()
 

--- a/cmake/scripts/common/PrepareEnv.cmake
+++ b/cmake/scripts/common/PrepareEnv.cmake
@@ -1,4 +1,4 @@
-# parse version.txt to get the version and API info
+# parse version.txt and libKODI_guilib.h to get the version and API info
 include(${CORE_SOURCE_DIR}/cmake/scripts/common/Macros.cmake)
 core_find_versions()
 

--- a/xbmc/addons/AddonDll.cpp
+++ b/xbmc/addons/AddonDll.cpp
@@ -283,7 +283,8 @@ bool CAddonDll::CheckAPIVersion(int type)
 {
   /* check the API version */
   const char* kodiVersion = kodi::addon::GetTypeVersion(type);
-  const char* addonVersion = m_pDll->GetAddonTypeVersion(type);
+  const char* addonVersion = nullptr;
+  m_pDll->GetAddonTypeVersion(type, &addonVersion);
 
   if (AddonVersion(addonVersion) != AddonVersion(kodiVersion))
   {

--- a/xbmc/addons/DllAddon.h
+++ b/xbmc/addons/DllAddon.h
@@ -35,7 +35,8 @@ public:
   virtual unsigned int GetSettings(ADDON_StructSetting*** sSet)=0;
   virtual void FreeSettings()=0;
   virtual ADDON_STATUS SetSetting(const char *settingName, const void *settingValue) =0;
-  virtual const char* GetAddonTypeVersion(int type)=0;
+  // Needed to pass return value as 'version' this way to prevent 'error C2059: Syntaxerror: "__declspec(dllexport)"' on Windows
+  virtual void GetAddonTypeVersion(int type, const char** version)=0;
 };
 
 class DllAddon : public DllDynamic, public DllAddonInterface
@@ -50,7 +51,7 @@ public:
   DEFINE_METHOD0(void, FreeSettings)
   DEFINE_METHOD2(ADDON_STATUS, SetSetting, (const char *p1, const void *p2))
   DEFINE_METHOD1(void, GetAddon, (void* p1))
-  DEFINE_METHOD1(const char*, GetAddonTypeVersion, (int p1))
+  DEFINE_METHOD2(void, GetAddonTypeVersion, (int p1, const char** p2))
   BEGIN_METHOD_RESOLVE()
     RESOLVE_METHOD_RENAME(get_addon,GetAddon)
     RESOLVE_METHOD_RENAME(ADDON_Create, Create)

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_guilib.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/libKODI_guilib.h
@@ -170,10 +170,10 @@ typedef struct CB_GUILib
 
 
 /* current ADDONGUI API version */
-#define KODI_GUILIB_API_VERSION "5.11.0"
+#define KODI_GUILIB_API_VERSION "5.11.1"
 
 /* min. ADDONGUI API version */
-#define KODI_GUILIB_MIN_API_VERSION "5.10.0"
+#define KODI_GUILIB_MIN_API_VERSION "5.11.1"
 
 #define ADDON_ACTION_PREVIOUS_MENU          10
 #define ADDON_ACTION_CLOSE_DIALOG           51

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -38,18 +38,18 @@
  * overview.
  */
 
-#define GLOBAL_VERSION_MAIN                     "1.0.0"
-#define GLOBAL_VERSION_GUI                      "5.11.1"
+#define ADDON_GLOBAL_VERSION_MAIN                     "1.0.0"
+#define ADDON_GLOBAL_VERSION_GUI                      "5.11.1"
 
-#define INSTANCE_VERSION_ADSP                   "0.1.10"
-#define INSTANCE_VERSION_AUDIODECODER           "1.0.1"
-#define INSTANCE_VERSION_AUDIOENCODER           "1.0.1"
-#define INSTANCE_VERSION_GAME                   "1.0.29"
-#define INSTANCE_VERSION_INPUTSTREAM            "1.0.8"
-#define INSTANCE_VERSION_PERIPHERAL             "1.2.3"
-#define INSTANCE_VERSION_PVR                    "5.2.3"
-#define INSTANCE_VERSION_SCREENSAVER            "1.0.1"
-#define INSTANCE_VERSION_VISUALIZATION          "1.0.1"
+#define ADDON_INSTANCE_VERSION_ADSP                   "0.1.10"
+#define ADDON_INSTANCE_VERSION_AUDIODECODER           "1.0.1"
+#define ADDON_INSTANCE_VERSION_AUDIOENCODER           "1.0.1"
+#define ADDON_INSTANCE_VERSION_GAME                   "1.0.29"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "1.0.8"
+#define ADDON_INSTANCE_VERSION_PERIPHERAL             "1.2.3"
+#define ADDON_INSTANCE_VERSION_PVR                    "5.2.3"
+#define ADDON_INSTANCE_VERSION_SCREENSAVER            "1.0.1"
+#define ADDON_INSTANCE_VERSION_VISUALIZATION          "1.0.1"
 
 /*
  * The currently used types for Kodi add-ons
@@ -96,29 +96,29 @@ inline const char* GetTypeVersion(int type)
   {
     /* addon global parts */
     case ADDON_GLOBAL_MAIN:
-      return GLOBAL_VERSION_MAIN;
+      return ADDON_GLOBAL_VERSION_MAIN;
     case ADDON_GLOBAL_GUI:
-      return GLOBAL_VERSION_GUI;
+      return ADDON_GLOBAL_VERSION_GUI;
 
     /* addon type instances */
     case ADDON_INSTANCE_ADSP:
-      return INSTANCE_VERSION_ADSP;
+      return ADDON_INSTANCE_VERSION_ADSP;
     case ADDON_INSTANCE_AUDIODECODER:
-      return INSTANCE_VERSION_AUDIODECODER;
+      return ADDON_INSTANCE_VERSION_AUDIODECODER;
     case ADDON_INSTANCE_AUDIOENCODER:
-      return INSTANCE_VERSION_AUDIOENCODER;
+      return ADDON_INSTANCE_VERSION_AUDIOENCODER;
     case ADDON_INSTANCE_GAME:
-      return INSTANCE_VERSION_GAME;
+      return ADDON_INSTANCE_VERSION_GAME;
     case ADDON_INSTANCE_INPUTSTREAM:
-      return INSTANCE_VERSION_INPUTSTREAM;
+      return ADDON_INSTANCE_VERSION_INPUTSTREAM;
     case ADDON_INSTANCE_PERIPHERAL:
-      return INSTANCE_VERSION_PERIPHERAL;
+      return ADDON_INSTANCE_VERSION_PERIPHERAL;
     case ADDON_INSTANCE_PVR:
-      return INSTANCE_VERSION_PVR;
+      return ADDON_INSTANCE_VERSION_PVR;
     case ADDON_INSTANCE_SCREENSAVER:
-      return INSTANCE_VERSION_SCREENSAVER;
+      return ADDON_INSTANCE_VERSION_SCREENSAVER;
     case ADDON_INSTANCE_VISUALIZATION:
-      return INSTANCE_VERSION_VISUALIZATION;
+      return ADDON_INSTANCE_VERSION_VISUALIZATION;
   }
   return "0.0.0";
 }

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_addon_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_addon_dll.h
@@ -45,9 +45,9 @@ extern "C" {
   unsigned int __declspec(dllexport) ADDON_GetSettings(ADDON_StructSetting ***sSet);
   ADDON_STATUS __declspec(dllexport) ADDON_SetSetting(const char *settingName, const void *settingValue);
   void         __declspec(dllexport) ADDON_FreeSettings();
-  const char* __declspec(dllexport) ADDON_GetTypeVersion(int type)
+  void __declspec(dllexport) ADDON_GetTypeVersion(int type, const char** version)
   {
-    return kodi::addon::GetTypeVersion(type);
+    *version = kodi::addon::GetTypeVersion(type);
   }
 
 #ifdef __cplusplus


### PR DESCRIPTION
This commits fix with one the stupid build fault on windows where `__declspec(dllexport)` can not work with a `const char*` as return.
One revert the changes for guilib addon.xml
Also becomes the version definition parts from versions.h renamed to have later equal with them used on cmake.