### PR TITLE
[jenkins] allow override of cpu build threads on locally used systems

### DIFF
--- a/tools/buildsteps/win32/buildhelpers.sh
+++ b/tools/buildsteps/win32/buildhelpers.sh
@@ -4,17 +4,23 @@ MAKEFLAGS="$1"
 BGPROCESSFILE="$2"
 tools="$3"
 
-cpuCount=1
-if [ $NUMBER_OF_PROCESSORS > 1 ]; then
-  if [ $NUMBER_OF_PROCESSORS > 4 ]; then
-    cpuCount=6
-  else
-    cpuCount=`expr $NUMBER_OF_PROCESSORS + $NUMBER_OF_PROCESSORS / 2`
+if [[ -z $BUILDTHREADS ]]; then
+  cpuCount=1
+  if [ $NUMBER_OF_PROCESSORS > 1 ]; then
+    if [ $NUMBER_OF_PROCESSORS > 4 ]; then
+      cpuCount=6
+    else
+      cpuCount=`expr $NUMBER_OF_PROCESSORS + $NUMBER_OF_PROCESSORS / 2`
+    fi
   fi
+  if [[ ! $cpuCount =~ ^[0-9]+$ ]]; then
+    cpuCount="$(($(nproc)/2))"
+  fi
+else
+  cpuCount=$BUILDTHREADS
 fi
-if [[ ! $cpuCount =~ ^[0-9]+$ ]]; then
-  cpuCount="$(($(nproc)/2))"
-fi
+
+echo "Amount of cpu build jobs $([[ -z $BUILDTHREADS ]] && echo "calculated by system check" || echo "defined by global variable"): '$cpuCount'"
 
 if which tput >/dev/null 2>&1; then
     ncolors=$(tput colors)


### PR DESCRIPTION
This is related to https://github.com/xbmc/xbmc/pull/10941

Want to have it for override the system build threads to have one time the windows build working without stupid reworks during compile.