### PR TITLE
[addons] add initial base add-on C++ support

### DIFF
--- a/xbmc/addons/AddonDll.cpp
+++ b/xbmc/addons/AddonDll.cpp
@@ -244,7 +244,7 @@ ADDON_STATUS CAddonDll::Create(int type, void* funcTable, void* info)
 /*!
  * @todo This function becomes a lot of changes until final
  */
-ADDON_STATUS CAddonDll::Create()
+ADDON_STATUS CAddonDll::Create(KODI_HANDLE firstKodiInstance)
 {
   CLog::Log(LOGDEBUG, "ADDON: Dll Initializing - %s", Name().c_str());
   m_initialized = false;
@@ -264,7 +264,7 @@ ADDON_STATUS CAddonDll::Create()
 
   /* Call Create to make connections, initializing data or whatever is
      needed to become the AddOn running */
-  ADDON_STATUS status = m_pDll->Create(nullptr, nullptr); /*! @todo Values becomes changed after the system is reworked complete, now there to prevent conflicts */
+  ADDON_STATUS status = m_pDll->Create(nullptr, firstKodiInstance); /*! @todo Values becomes changed after the system is reworked complete, now there to prevent conflicts */
   if (status == ADDON_STATUS_OK)
   {
     m_initialized = true;
@@ -376,7 +376,7 @@ ADDON_STATUS CAddonDll::CreateInstance(int instanceType, const std::string& inst
   ADDON_STATUS status = ADDON_STATUS_PERMANENT_FAILURE;
 
   if (!m_initialized)
-    status = Create();
+    status = Create(instance);
   if (status != ADDON_STATUS_OK)
     return status;
 

--- a/xbmc/addons/AddonDll.cpp
+++ b/xbmc/addons/AddonDll.cpp
@@ -169,6 +169,9 @@ bool CAddonDll::LoadDll()
   return true;
 }
 
+/*!
+ * @todo this function becomes removed on final 
+ */
 ADDON_STATUS CAddonDll::Create(int type, void* funcTable, void* info)
 {
   /* ensure that a previous instance is destroyed */
@@ -238,6 +241,60 @@ ADDON_STATUS CAddonDll::Create(int type, void* funcTable, void* info)
   return status;
 }
 
+/*!
+ * @todo This function becomes a lot of changes until final
+ */
+ADDON_STATUS CAddonDll::Create()
+{
+  CLog::Log(LOGDEBUG, "ADDON: Dll Initializing - %s", Name().c_str());
+  m_initialized = false;
+
+  if (!LoadDll())
+  {
+    CGUIDialogOK::ShowAndGetInput(CVariant{24070}, CVariant{16029});
+    return ADDON_STATUS_PERMANENT_FAILURE;
+  }
+
+  /* Check versions about global parts on add-on (parts used on all types) */
+  for (unsigned int id = ADDON_GLOBAL_MAIN; id <= ADDON_GLOBAL_MAX; ++id)
+  {
+    if (!CheckAPIVersion(id))
+      return ADDON_STATUS_PERMANENT_FAILURE;
+  }
+
+  /* Call Create to make connections, initializing data or whatever is
+     needed to become the AddOn running */
+  ADDON_STATUS status = m_pDll->Create(nullptr, nullptr); /*! @todo Values becomes changed after the system is reworked complete, now there to prevent conflicts */
+  if (status == ADDON_STATUS_OK)
+  {
+    m_initialized = true;
+  }
+  else if ((status == ADDON_STATUS_NEED_SETTINGS) || (status == ADDON_STATUS_NEED_SAVEDSETTINGS))
+  {
+    m_needsavedsettings = (status == ADDON_STATUS_NEED_SAVEDSETTINGS);
+    if ((status = TransferSettings()) == ADDON_STATUS_OK)
+      m_initialized = true;
+    else
+      new CAddonStatusHandler(ID(), status, "", false);
+  }
+  else
+  { // Addon failed initialization
+    CLog::Log(LOGERROR, "ADDON: Dll %s - Client returned bad status (%i) from Create and is not usable", Name().c_str(), status);
+
+    CGUIDialogOK* pDialog = (CGUIDialogOK*)g_windowManager.GetWindow(WINDOW_DIALOG_OK);
+    if (pDialog)
+    {
+      std::string heading = StringUtils::Format("%s: %s", TranslateType(Type(), true).c_str(), Name().c_str());
+      pDialog->SetHeading(CVariant{heading});
+      pDialog->SetLine(1, CVariant{24070});
+      pDialog->SetLine(2, CVariant{24071});
+      pDialog->Open();
+    }
+  }
+
+  return status;
+}
+
 void CAddonDll::Destroy()
 {
   if (m_pDll)
@@ -276,6 +333,14 @@ void CAddonDll::Destroy()
     m_pDll = NULL;
     CLog::Log(LOGINFO, "ADDON: Dll Destroyed - %s", Name().c_str());
   }
+
+  /* Make sure all instances are destroyed if interface becomes stopped. */
+  for (std::map<std::string, std::pair<int, KODI_HANDLE>>::iterator it = m_usedInstances.begin(); it != m_usedInstances.end(); ++it)
+  {
+    m_pDll->DestroyInstance(it->second.first, it->second.second);
+    m_usedInstances.erase(it);
+  }
+
   m_initialized = false;
 }
 
@@ -303,6 +368,43 @@ bool CAddonDll::CheckAPIVersion(int type)
   }
 
   return true;
+}
+
+/*! @todo there comes further changes until it is final! */
+ADDON_STATUS CAddonDll::CreateInstance(int instanceType, const std::string& instanceID, KODI_HANDLE instance, KODI_HANDLE* addonInstance)
+{
+  ADDON_STATUS status = ADDON_STATUS_PERMANENT_FAILURE;
+
+  if (!m_initialized)
+    status = Create();
+  if (status != ADDON_STATUS_OK)
+    return status;
+
+  /* Check version of requested instance type */
+  if (!CheckAPIVersion(instanceType))
+    return ADDON_STATUS_PERMANENT_FAILURE;
+
+  status = m_pDll->CreateInstance(instanceType, instanceID.c_str(), instance, addonInstance);
+  if (status == ADDON_STATUS_OK)
+  {
+    m_usedInstances[instanceID] = std::make_pair(instanceType, *addonInstance);
+  }
+
+  return status;
+}
+
+/*! @todo there comes further changes until it is final! */
+void CAddonDll::DestroyInstance(const std::string& instanceID)
+{
+  std::map<std::string, std::pair<int, KODI_HANDLE>>::iterator it = m_usedInstances.find(instanceID);
+  if (it != m_usedInstances.end())
+  {
+    m_pDll->DestroyInstance(it->second.first, it->second.second);
+    m_usedInstances.erase(it);
+  }
+
+  if (m_usedInstances.empty())
+    Destroy();
 }
 
 bool CAddonDll::DllLoaded(void) const

--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -42,10 +42,14 @@ namespace ADDON
     virtual void SaveSettings();
     virtual std::string GetSetting(const std::string& key);
 
+    ADDON_STATUS Create();
     ADDON_STATUS Create(int type, void* funcTable, void* info);
     void Destroy();
 
     bool DllLoaded(void) const;
+
+    ADDON_STATUS CreateInstance(int instanceType, const std::string& instanceID, KODI_HANDLE instance, KODI_HANDLE* addonInstance);
+    void DestroyInstance(const std::string& instanceID);
 
   protected:
     bool Initialized() { return m_initialized; }
@@ -60,6 +64,7 @@ namespace ADDON
     bool m_initialized;
     bool LoadDll();
     bool m_needsavedsettings;
+    std::map<std::string, std::pair<int, KODI_HANDLE>> m_usedInstances;
 
     virtual ADDON_STATUS TransferSettings();
     TiXmlElement MakeSetting(DllSetting& setting) const;

--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -42,7 +42,7 @@ namespace ADDON
     virtual void SaveSettings();
     virtual std::string GetSetting(const std::string& key);
 
-    ADDON_STATUS Create();
+    ADDON_STATUS Create(KODI_HANDLE firstKodiInstance);
     ADDON_STATUS Create(int type, void* funcTable, void* info);
     void Destroy();
 

--- a/xbmc/addons/DllAddon.h
+++ b/xbmc/addons/DllAddon.h
@@ -21,7 +21,7 @@
 
 #include "DynamicDll.h"
 #include "addons/kodi-addon-dev-kit/include/kodi/xbmc_addon_cpp_dll.h"
-#include "addons/kodi-addon-dev-kit/include/kodi/versions.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/AddonBase.h"
 
 class DllAddonInterface
 {
@@ -36,6 +36,8 @@ public:
   virtual void FreeSettings()=0;
   virtual ADDON_STATUS SetSetting(const char *settingName, const void *settingValue) =0;
   virtual const char* GetAddonTypeVersion(int type)=0;
+  virtual ADDON_STATUS CreateInstance(int instanceType, const char* instanceID, KODI_HANDLE instance, KODI_HANDLE* addonInstance) =0;
+  virtual void DestroyInstance(int instanceType, KODI_HANDLE instance) =0;
 };
 
 class DllAddon : public DllDynamic, public DllAddonInterface
@@ -51,6 +53,8 @@ public:
   DEFINE_METHOD2(ADDON_STATUS, SetSetting, (const char *p1, const void *p2))
   DEFINE_METHOD1(void, GetAddon, (void* p1))
   DEFINE_METHOD1(const char*, GetAddonTypeVersion, (int p1))
+  DEFINE_METHOD4(ADDON_STATUS, CreateInstance, (int p1, const char* p2, KODI_HANDLE p3, KODI_HANDLE* p4))
+  DEFINE_METHOD2(void, DestroyInstance, (int p1, KODI_HANDLE p2))
   BEGIN_METHOD_RESOLVE()
     RESOLVE_METHOD_RENAME(get_addon,GetAddon)
     RESOLVE_METHOD_RENAME(ADDON_Create, Create)
@@ -61,6 +65,8 @@ public:
     RESOLVE_METHOD_RENAME(ADDON_GetSettings, GetSettings)
     RESOLVE_METHOD_RENAME(ADDON_FreeSettings, FreeSettings)
     RESOLVE_METHOD_RENAME(ADDON_GetTypeVersion, GetAddonTypeVersion)
+    RESOLVE_METHOD_RENAME(ADDON_CreateInstance, CreateInstance)
+    RESOLVE_METHOD_RENAME(ADDON_DestroyInstance, DestroyInstance)
   END_METHOD_RESOLVE()
 };
 

--- a/xbmc/addons/ScreenSaver.h
+++ b/xbmc/addons/ScreenSaver.h
@@ -46,6 +46,7 @@ private:
   std::string m_presets; /*!< To add-on sended preset path */
   std::string m_profile; /*!< To add-on sended profile path */
 
+  KODI_HANDLE m_addonInstance;
   AddonInstance_ScreenSaver m_struct;
 };
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
@@ -103,5 +103,311 @@ typedef ADDON_HANDLE_STRUCT *ADDON_HANDLE;
 #define ADDON_STANDARD_STRING_LENGTH_SMALL 256
 
 #ifdef __cplusplus
-}
+namespace kodi {
+namespace addon {
+
+  //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+  //
+  class IAddonInstance
+  {
+  public:
+    IAddonInstance(ADDON_TYPE type) : m_type(type) { }
+    virtual ~IAddonInstance() { }
+
+    const ADDON_TYPE m_type;
+  };
+  //
+  //=-----=------=------=------=------=------=------=------=------=------=-----=
+
+
+  //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+  // Add-on settings handle class
+  //
+  class CAddonSetting
+  {
+  public:
+    enum SETTING_TYPE { NONE=0, CHECK, SPIN };
+
+    CAddonSetting(SETTING_TYPE type, std::string id, std::string label)
+      : Type(type),
+        Id(id),
+        Label(label),
+        Current(0)
+    {
+    }
+
+    CAddonSetting(const CAddonSetting &rhs) // copy constructor
+    {
+      Id = rhs.Id;
+      Label = rhs.Label;
+      Current = rhs.Current;
+      Type = rhs.Type;
+      for (unsigned int i = 0; i < rhs.Entries.size(); ++i)
+        Entries.push_back(rhs.Entries[i]);
+    }
+
+    void AddEntry(std::string label)
+    {
+      if (Label.empty() || Type != SPIN)
+        return;
+      Entries.push_back(Label);
+    }
+
+    // data members
+    SETTING_TYPE Type;
+    std::string Id;
+    std::string Label;
+    int Current;
+    std::vector<std::string> Entries;
+  };
+  //
+  //=-----=------=------=------=------=------=------=------=------=------=-----=
+
+
+  //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+  // Function used on Kodi itself to transfer back from add-on given data with
+  // "ADDON_StructSetting***" to "std::vector<CAddonSetting>"
+  //
+  // Note: Not needed on add-on itself, only here to have all related parts on
+  // same place!
+  //
+  static inline void StructToVec(unsigned int elements, ADDON_StructSetting*** sSet, std::vector<CAddonSetting> *vecSet)
+  {
+    if (elements == 0)
+      return;
+
+    vecSet->clear();
+    for(unsigned int i = 0; i < elements; i++)
+    {
+      CAddonSetting vSet((CAddonSetting::SETTING_TYPE)(*sSet)[i]->type, (*sSet)[i]->id, (*sSet)[i]->label);
+      if((*sSet)[i]->type == CAddonSetting::SPIN)
+      {
+        for(unsigned int j=0;j<(*sSet)[i]->entry_elements;j++)
+        {
+          vSet.AddEntry((*sSet)[i]->entry[j]);
+        }
+      }
+      vSet.Current = (*sSet)[i]->current;
+      vecSet->push_back(vSet);
+    }
+  }
+  //
+  //=-----=------=------=------=------=------=------=------=------=------=-----=
+
+
+  //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+  // Add-on main instance class.
+  //
+  class CAddonBase
+  {
+  public:
+    CAddonBase()
+    {
+    }
+
+    virtual ADDON_STATUS Create() { return ADDON_STATUS_OK; }
+
+    virtual ADDON_STATUS GetStatus() { return ADDON_STATUS_OK; }
+
+    virtual bool HasSettings() { return false; }
+
+    virtual bool GetSettings(std::vector<CAddonSetting>& settings) { return false; }
+
+    virtual ADDON_STATUS SetSetting(std::string& settingName, const void *settingValue) { return ADDON_STATUS_UNKNOWN; }
+
+    virtual ADDON_STATUS CreateInstance(int instanceType, std::string instanceID, KODI_HANDLE instance, KODI_HANDLE& addonInstance)
+    {
+      /* The handling below is intended for the case of the add-on only one
+       * instance and this is integrated in the add-on base class.
+       */
+
+      /* Check about single instance usage */
+      if (m_firstKodiInstance == instance && // the kodi side instance pointer must be equal to first one
+          m_globalSingleInstance &&  // the addon side instance pointer must be set
+          static_cast<::kodi::addon::IAddonInstance*>(m_globalSingleInstance)->m_type == instanceType) // and the requested type must be equal with used add-on class
+      {
+        addonInstance = m_globalSingleInstance;
+        return ADDON_STATUS_OK;
+      }
+
+      return ADDON_STATUS_UNKNOWN;
+    }
+
+    /* Global variables of class */
+    static CAddonBase* m_createdAddon; // Base add-on class pointer, needed to save startet main class
+    static KODI_HANDLE m_globalSingleInstance; // Pointer to a instance used on single way (together with this class)
+    static KODI_HANDLE m_firstKodiInstance; // Pointer of first created instance, used in case this add-on goes with single way
+
+  /*private:*/ /* Needed public as long the old call functions becomes used! */
+    static inline void ADDONBASE_Destroy()
+    {
+      delete CAddonBase::m_createdAddon;
+      CAddonBase::m_createdAddon = nullptr;
+    }
+
+    static inline ADDON_STATUS ADDONBASE_GetStatus() { return CAddonBase::m_createdAddon->GetStatus(); }
+
+    static inline bool ADDONBASE_HasSettings() { return CAddonBase::m_createdAddon->HasSettings(); }
+
+    static inline unsigned int ADDONBASE_GetSettings(ADDON_StructSetting ***sSet)
+    {
+      std::vector<CAddonSetting> settings;
+      if (CAddonBase::m_createdAddon->GetSettings(settings))
+      {
+        *sSet = nullptr;
+        if (settings.empty())
+          return 0;
+
+        *sSet = (ADDON_StructSetting**)malloc(settings.size()*sizeof(ADDON_StructSetting*));
+        for (unsigned int i = 0;i < settings.size(); ++i)
+        {
+          (*sSet)[i] = nullptr;
+          (*sSet)[i] = (ADDON_StructSetting*)malloc(sizeof(ADDON_StructSetting));
+          (*sSet)[i]->id = nullptr;
+          (*sSet)[i]->label = nullptr;
+
+          if (!settings[i].Id.empty() && !settings[i].Label.empty())
+          {
+            (*sSet)[i]->id = strdup(settings[i].Id.c_str());
+            (*sSet)[i]->label = strdup(settings[i].Label.c_str());
+            (*sSet)[i]->type = settings[i].Type;
+            (*sSet)[i]->current = settings[i].Current;
+            (*sSet)[i]->entry_elements = 0;
+            (*sSet)[i]->entry = nullptr;
+            if (settings[i].Type == CAddonSetting::SPIN && !settings[i].Entries.empty())
+            {
+              (*sSet)[i]->entry = (char**)malloc(settings[i].Entries.size()*sizeof(char**));
+              for (unsigned int j = 0; j < settings[i].Entries.size(); ++j)
+              {
+                if (!settings[i].Entries[j].empty())
+                {
+                  (*sSet)[i]->entry[j] = strdup(settings[i].Entries[j].c_str());
+                  (*sSet)[i]->entry_elements++;
+                }
+              }
+            }
+          }
+        }
+
+        return settings.size();
+      }
+      return 0;
+    }
+
+    static inline ADDON_STATUS ADDONBASE_SetSetting(const char *settingName, const void *settingValue)
+    {
+      std::string name = settingName;
+      ADDON_STATUS ret = CAddonBase::m_createdAddon->SetSetting(name, settingValue);
+      std::strcpy((char*)settingName, name.c_str());
+      return ret;
+    }
+
+    static inline void ADDONBASE_FreeSettings(unsigned int elements, ADDON_StructSetting*** set)
+    {
+      if (elements == 0)
+        return;
+
+      for (unsigned int i = 0; i < elements; ++i)
+      {
+        if ((*set)[i]->type == CAddonSetting::SPIN)
+        {
+          for (unsigned int j = 0; j < (*set)[i]->entry_elements; ++j)
+          {
+            free((*set)[i]->entry[j]);
+          }
+          free((*set)[i]->entry);
+        }
+        free((*set)[i]->id);
+        free((*set)[i]->label);
+        free((*set)[i]);
+      }
+      free(*set);
+    }
+
+    static inline ADDON_STATUS ADDONBASE_CreateInstance(int instanceType, const char* instanceID, KODI_HANDLE instance, KODI_HANDLE* addonInstance)
+    {
+      ADDON_STATUS status = CAddonBase::m_createdAddon->CreateInstance(instanceType, instanceID, instance, *addonInstance);
+      if (*addonInstance == nullptr)
+        throw std::logic_error("kodi::addon::CAddonBase CreateInstance returns a empty instance pointer!");
+
+      if (static_cast<::kodi::addon::IAddonInstance*>(*addonInstance)->m_type != instanceType)
+        throw std::logic_error("kodi::addon::CAddonBase CreateInstance with difference on given and returned instance type!");
+
+      return status;
+    }
+
+    static inline void ADDONBASE_DestroyInstance(int instanceType, KODI_HANDLE instance)
+    {
+      if (m_globalSingleInstance == nullptr && instance != CAddonBase::m_createdAddon)
+      {
+        if (static_cast<::kodi::addon::IAddonInstance*>(instance)->m_type == instanceType)
+          delete static_cast<::kodi::addon::IAddonInstance*>(instance);
+        else
+          throw std::logic_error("kodi::addon::CAddonBase DestroyInstance called with difference on given and present instance type!");
+      }
+    }
+  };
+  //
+  //=-----=------=------=------=------=------=------=------=------=------=-----=
+
+} /* namespace addon */
+} /* namespace kodi */
+} /* extern "C" */
 #endif /* __cplusplus */
+
+
+/*! addon creation macro
+ * @todo cleanup this stupid big macro
+ * This macro includes now all for add-on's needed functions. This becomes a bigger
+ * rework after everything is done on Kodi itself, currently is this way needed
+ * to have compatibility with not reworked interfaces.
+ *
+ * Becomes really cleaned up soon :D
+ */
+#define ADDONCREATOR(AddonClass) \
+  extern "C" __declspec(dllexport) void get_addon(void* pAddon) {} \
+  extern "C" __declspec(dllexport) ADDON_STATUS ADDON_Create(void *cb, void *firstKodiInstance) \
+  { \
+    kodi::addon::CAddonBase::m_firstKodiInstance = firstKodiInstance; \
+    kodi::addon::CAddonBase::m_createdAddon = new AddonClass; \
+    return kodi::addon::CAddonBase::m_createdAddon->Create(); \
+  } \
+  extern "C" __declspec(dllexport) void ADDON_Destroy() \
+  { \
+    kodi::addon::CAddonBase::ADDONBASE_Destroy(); \
+  } \
+  extern "C" __declspec(dllexport) ADDON_STATUS ADDON_GetStatus() \
+  { \
+    return kodi::addon::CAddonBase::ADDONBASE_GetStatus(); \
+  } \
+  extern "C" __declspec(dllexport) bool ADDON_HasSettings() \
+  { \
+    return kodi::addon::CAddonBase::ADDONBASE_HasSettings(); \
+  } \
+  extern "C" __declspec(dllexport) unsigned int ADDON_GetSettings(ADDON_StructSetting*** sSet) \
+  { \
+    return kodi::addon::CAddonBase::ADDONBASE_GetSettings(sSet); \
+  } \
+  extern "C" __declspec(dllexport) void ADDON_FreeSettings() \
+  { \
+    kodi::addon::CAddonBase::ADDONBASE_FreeSettings(0, nullptr); /* Currently bad but becomes soon changed! */ \
+  } \
+  extern "C" __declspec(dllexport) ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue) \
+  { \
+    return kodi::addon::CAddonBase::ADDONBASE_SetSetting(settingName, settingValue); \
+  } \
+  extern "C" __declspec(dllexport) const char* ADDON_GetTypeVersion(int type) \
+  { \
+    return kodi::addon::GetTypeVersion(type); \
+  } \
+  extern "C" __declspec(dllexport) ADDON_STATUS ADDON_CreateInstance(int instanceType, const char* instanceID, KODI_HANDLE instance, KODI_HANDLE* addonInstance) \
+  { \
+    return kodi::addon::CAddonBase::ADDONBASE_CreateInstance(instanceType, instanceID, instance, addonInstance); \
+  } \
+  extern "C" __declspec(dllexport) void ADDON_DestroyInstance(int instanceType, KODI_HANDLE instance) \
+  { \
+    kodi::addon::CAddonBase::ADDONBASE_DestroyInstance(instanceType, instance); \
+  } \
+  kodi::addon::CAddonBase* kodi::addon::CAddonBase::m_createdAddon = nullptr; \
+  KODI_HANDLE kodi::addon::CAddonBase::m_globalSingleInstance = nullptr; \
+  KODI_HANDLE kodi::addon::CAddonBase::m_firstKodiInstance = nullptr;

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_addon_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_addon_dll.h
@@ -20,19 +20,7 @@
  *
  */
 
-#ifdef TARGET_WINDOWS
-#include <windows.h>
-#else
-#ifndef __cdecl
-#define __cdecl
-#endif
-#ifndef __declspec
-#define __declspec(X)
-#endif
-#endif
-
-#include "xbmc_addon_types.h"
-#include "versions.h"
+#include "AddonBase.h"
 
 #ifdef __cplusplus
 extern "C" { 
@@ -49,6 +37,8 @@ extern "C" {
   {
     return kodi::addon::GetTypeVersion(type);
   }
+  __declspec(dllexport) ADDON_STATUS ADDON_CreateInstance(int instanceType, const char* instanceID, KODI_HANDLE instance, KODI_HANDLE* addonInstance);
+  __declspec(dllexport) void ADDON_DestroyInstance(int instanceType, KODI_HANDLE instance);
 
 #ifdef __cplusplus
 };

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_scr_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_scr_dll.h
@@ -1,5 +1,4 @@
 #pragma once
-
 /*
  *      Copyright (C) 2005-2015 Team Kodi
  *      http://kodi.tv
@@ -27,18 +26,10 @@ extern "C"
 {
 
   // Functions that your visualisation must implement
-  void Start();
-  void Stop();
-  void Render();
+  void Start(KODI_HANDLE addonHandle);
+  void Stop(KODI_HANDLE addonHandle);
+  void Render(KODI_HANDLE addonHandle);
 
-  // function to export the above structure to XBMC
-  void __declspec(dllexport) get_addon(void* ptr)
-  {
-    KodiToAddonFuncTable_Screensaver* pScr = static_cast<KodiToAddonFuncTable_Screensaver*>(ptr);
-
-    pScr->Start = Start;
-    pScr->Stop = Stop;
-    pScr->Render = Render;
-  };
+  // No more needed, stays here to prevent load faults as long function is needed by other types!
+  void __declspec(dllexport) get_addon(void* ptr) { }
 };
-

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_scr_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_scr_types.h
@@ -45,9 +45,9 @@ typedef struct AddonToKodiFuncTable_Screensaver
 
 typedef struct KodiToAddonFuncTable_Screensaver
 {
-  void (__cdecl* Start) ();
-  void (__cdecl* Stop) ();
-  void (__cdecl* Render) ();
+  void (__cdecl* Start) (KODI_HANDLE addonHandle);
+  void (__cdecl* Stop) (KODI_HANDLE addonHandle);
+  void (__cdecl* Render) (KODI_HANDLE addonHandle);
 } KodiToAddonFuncTable_Screensaver;
 
 typedef struct AddonInstance_ScreenSaver


### PR DESCRIPTION
This request update/add the complete reworked new header `AddonBase.h` for the add-on base who was before only in `C`, now complete in `C++`.

With them becomes a lot of not needed work removed on add-on's.

For backward compatibility use it currently still the old interface functions who are set by macro `ADDONCREATOR` but on end becomes this cleaned up and all functions except ADDON_Create are done by another way.

Until final come for them improvements and cleanups.

Tested here currently only with screensavers.