### PR TITLE
[addons] add first initial new addon to kodi callbacks

### DIFF
--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -78,6 +78,19 @@ namespace ADDON
     static bool AddOnGetSetting(void *userData, const char *settingName, void *settingValue);
     static void AddOnOpenSettings(const char *url, bool bReload);
     static void AddOnOpenOwnSettings(void *userData, bool bReload);
+
+    /// addon to kodi basic callbacks below
+    //@{
+    FuncTable_Addon m_interface;
+
+    bool InitInterfaceFunctions();
+    void DeInitInterfaceFunctions();
+
+    static char* get_addon_path(void* kodiInstance);
+    static char* get_base_user_path(void* kodiInstance);
+    static void addon_log_msg(void* kodiInstance, const int addonLogLevel, const char* strMessage);
+    static void free_string(void* kodiInstance, char* str);
+    //@}
   };
 
   /*!


### PR DESCRIPTION
This add the first callbacks over the new way to add-on header. With them
is on add-on start the table already set and something like "XBMC->RegisterMe(hdl)"
no more needed.

There comes a bigger cleanup of "AddonBase.h" after them is in.

Currently don't touch this the old way and all old style add-ons don't need a
rework.