### PR TITLE
[addons] cleanup main addon header AddonBase.h

### DIFF
--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -81,10 +81,10 @@ namespace ADDON
 
     /// addon to kodi basic callbacks below
     //@{
-    FuncTable_Addon m_interface;
+    AddonGlobalInterface m_interface;
 
-    bool InitInterfaceFunctions();
-    void DeInitInterfaceFunctions();
+    inline bool InitInterface(KODI_HANDLE firstKodiInstance);
+    inline void DeInitInterface();
 
     static char* get_addon_path(void* kodiInstance);
     static char* get_base_user_path(void* kodiInstance);

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/screensaver/Screensaver.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/screensaver/Screensaver.h
@@ -68,17 +68,17 @@ namespace addon
     CInstanceScreensaver()
       : IAddonInstance(ADDON_INSTANCE_SCREENSAVER)
     {
-      if (kodi::addon::CAddonBase::m_globalSingleInstance != nullptr)
+      if (CAddonBase::m_interface->globalSingleInstance != nullptr)
         throw std::logic_error("kodi::addon::CInstanceScreensaver: Creation of more as one in single instance way is not allowed!");
 
-      SetAddonStruct(kodi::addon::CAddonBase::m_firstKodiInstance);
-      kodi::addon::CAddonBase::m_globalSingleInstance = this;
+      SetAddonStruct(CAddonBase::m_interface->firstKodiInstance);
+      CAddonBase::m_interface->globalSingleInstance = this;
     }
 
     CInstanceScreensaver(KODI_HANDLE instance)
       : IAddonInstance(ADDON_INSTANCE_SCREENSAVER)
     {
-      if (kodi::addon::CAddonBase::m_globalSingleInstance != nullptr)
+      if (CAddonBase::m_interface->globalSingleInstance != nullptr)
         throw std::logic_error("kodi::addon::CInstanceScreensaver: Creation of multiple together with single instance way is not allowed!");
 
       SetAddonStruct(instance);


### PR DESCRIPTION
After last changes cleanup this the header to make it more clear.

Everything with a "/*" or "//" comment is used inside headers and not related
for add-on development itself.