### PR TITLE
[addons] add first global add-on callback interface

### DIFF
--- a/cmake/treedata/common/subdirs.txt
+++ b/cmake/treedata/common/subdirs.txt
@@ -9,6 +9,7 @@ xbmc/addons/interfaces/GUI                      addonCallbacks_GUI
 xbmc/addons/interfaces/InputStream              addonCallbacks_InputStream
 xbmc/addons/interfaces/Peripheral               addonCallbacks_Peripheral
 xbmc/addons/interfaces/PVR                      addonCallbacks_PVR
+xbmc/addons/interfaces/kodi                     addonInterface_kodi
 xbmc/addons/interfaces/kodi/screensaver         addonInterface_kodi_screensaver
 xbmc/commons                                    commons
 xbmc/dbwrappers                                 dbwrappers

--- a/cmake/treedata/common/subdirs.txt
+++ b/cmake/treedata/common/subdirs.txt
@@ -9,6 +9,7 @@ xbmc/addons/interfaces/GUI                      addonCallbacks_GUI
 xbmc/addons/interfaces/InputStream              addonCallbacks_InputStream
 xbmc/addons/interfaces/Peripheral               addonCallbacks_Peripheral
 xbmc/addons/interfaces/PVR                      addonCallbacks_PVR
+xbmc/addons/interfaces/kodi/screensaver         addonInterface_kodi_screensaver
 xbmc/commons                                    commons
 xbmc/dbwrappers                                 dbwrappers
 xbmc/dialogs                                    dialogs

--- a/xbmc/addons/AddonBuilder.cpp
+++ b/xbmc/addons/AddonBuilder.cpp
@@ -29,7 +29,6 @@
 #include "addons/PluginSource.h"
 #include "addons/Repository.h"
 #include "addons/Scraper.h"
-#include "addons/ScreenSaver.h"
 #include "addons/Service.h"
 #include "addons/Skin.h"
 #include "addons/UISoundsResource.h"

--- a/xbmc/addons/AddonDll.cpp
+++ b/xbmc/addons/AddonDll.cpp
@@ -33,6 +33,11 @@
 #include "utils/Variant.h"
 #include "Util.h"
 
+/*
+ * Standard addon interface function includes
+ */
+#include "addons/interfaces/kodi/General.h"
+
 namespace ADDON
 {
 
@@ -633,6 +638,8 @@ bool CAddonDll::InitInterface(KODI_HANDLE firstKodiInstance)
   m_interface.toKodi.get_base_user_path = get_base_user_path;
   m_interface.toKodi.addon_log_msg = addon_log_msg;
   m_interface.toKodi.free_string = free_string;
+
+  Interface_General::Init(&m_interface);
 
   return true;
 }

--- a/xbmc/addons/CMakeLists.txt
+++ b/xbmc/addons/CMakeLists.txt
@@ -26,7 +26,6 @@ set(SOURCES Addon.cpp
             Repository.cpp
             RepositoryUpdater.cpp
             Scraper.cpp
-            ScreenSaver.cpp
             Service.cpp
             Skin.cpp
             UISoundsResource.cpp
@@ -66,7 +65,6 @@ set(HEADERS Addon.h
             RepositoryUpdater.h
             Resource.h
             Scraper.h
-            ScreenSaver.h
             Service.h
             Skin.h
             UISoundsResource.h

--- a/xbmc/addons/interfaces/kodi/CMakeLists.txt
+++ b/xbmc/addons/interfaces/kodi/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(SOURCES General.cpp)
+
+set(HEADERS General.h)
+
+include_directories(${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include)
+
+core_add_library(addonInterface_kodi)
+
+if(ENABLE_INTERNAL_FFMPEG)
+  add_dependencies(addonInterface_kodi ffmpeg)
+endif()

--- a/xbmc/addons/interfaces/kodi/General.cpp
+++ b/xbmc/addons/interfaces/kodi/General.cpp
@@ -1,0 +1,150 @@
+/*
+ *      Copyright (C) 2012-2013 Team XBMC
+ *      Copyright (C) 2015-2016 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "General.h"
+
+#include "addons/kodi-addon-dev-kit/include/kodi/General.h"
+
+#include "ServiceBroker.h"
+#include "addons/AddonDll.h"
+#include "addons/GUIDialogAddonSettings.h"
+#include "settings/Settings.h"
+#include "utils/log.h"
+#include "utils/StringUtils.h"
+
+using namespace kodi; // addon-dev-kit namespace
+
+namespace ADDON
+{
+
+void Interface_General::Init(AddonGlobalInterface* interface)
+{
+  interface->toKodi.kodi = (AddonToKodiFuncTable_kodi*)malloc(sizeof(AddonToKodiFuncTable_kodi));
+  interface->toKodi.kodi->get_setting = get_setting;
+  interface->toKodi.kodi->open_settings_dialog = open_settings_dialog;
+}
+
+void Interface_General::DeInit(AddonGlobalInterface* interface)
+{
+  if (interface->toKodi.kodi)
+  {
+    free(interface->toKodi.kodi);
+    interface->toKodi.kodi = nullptr;
+  }
+}
+
+bool Interface_General::get_setting(void* kodiBase, const char* settingName, void* settingValue)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (addon == nullptr || settingName == nullptr || settingValue == nullptr)
+  {
+    CLog::Log(LOGERROR, "kodi::General::%s - invalid data (addon='%p', settingName='%p', settingValue='%p')",
+                                        __FUNCTION__, addon, settingName, settingValue);
+
+    return false;
+  }
+
+  CLog::Log(LOGDEBUG, "kodi::General::%s - add-on '%s' requests setting '%s'",
+                        __FUNCTION__, addon->Name().c_str(), settingName);
+
+  if (strcasecmp(settingName, "__addonpath__") == 0)
+  {
+    strcpy((char*) settingValue, addon->Path().c_str());
+    return true;
+  }
+
+  if (!addon->ReloadSettings())
+  {
+    CLog::Log(LOGERROR, "kodi::General::%s - could't get settings for add-on '%s'", __FUNCTION__, addon->Name().c_str());
+    return false;
+  }
+
+  const TiXmlElement *category = addon->GetSettingsXML()->FirstChildElement("category");
+  if (!category) // add a default one...
+    category = addon->GetSettingsXML();
+
+  while (category)
+  {
+    const TiXmlElement *setting = category->FirstChildElement("setting");
+    while (setting)
+    {
+      const std::string   id = XMLUtils::GetAttribute(setting, "id");
+      const std::string type = XMLUtils::GetAttribute(setting, "type");
+
+      if (id == settingName && !type.empty())
+      {
+        if (type == "text"     || type == "ipaddress" ||
+            type == "folder"   || type == "action"    ||
+            type == "music"    || type == "pictures"  ||
+            type == "programs" || type == "fileenum"  ||
+            type == "file"     || type == "labelenum")
+        {
+          strcpy((char*) settingValue, addon->GetSetting(id).c_str());
+          return true;
+        }
+        else if (type == "number" || type == "enum")
+        {
+          *(int*) settingValue = (int) atoi(addon->GetSetting(id).c_str());
+          return true;
+        }
+        else if (type == "bool")
+        {
+          *(bool*) settingValue = (bool) (addon->GetSetting(id) == "true" ? true : false);
+          return true;
+        }
+        else if (type == "slider")
+        {
+          const char *option = setting->Attribute("option");
+          if (option && strcmpi(option, "int") == 0)
+          {
+            *(int*) settingValue = (int) atoi(addon->GetSetting(id).c_str());
+            return true;
+          }
+          else
+          {
+            *(float*) settingValue = (float) atof(addon->GetSetting(id).c_str());
+            return true;
+          }
+        }
+      }
+      setting = setting->NextSiblingElement("setting");
+    }
+    category = category->NextSiblingElement("category");
+  }
+  CLog::Log(LOGERROR, "kodi::General::%s - can't find setting '%s' in '%s'", __FUNCTION__, settingName, addon->Name().c_str());
+
+  return false;
+}
+
+void Interface_General::open_settings_dialog(void* kodiBase)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (addon == nullptr)
+  {
+    CLog::Log(LOGERROR, "kodi::General::%s - called with a null pointer", __FUNCTION__);
+    return;
+  }
+
+  // show settings dialog
+  CGUIDialogAddonSettings::ShowAndGetInput(ADDON::AddonPtr(addon));
+}
+
+} /* namespace ADDON */

--- a/xbmc/addons/interfaces/kodi/General.h
+++ b/xbmc/addons/interfaces/kodi/General.h
@@ -1,0 +1,60 @@
+#pragma once
+/*
+ *      Copyright (C) 2012-2013 Team XBMC
+ *      Copyright (C) 2015-2016 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+struct AddonGlobalInterface;
+
+namespace ADDON
+{
+extern "C"
+{
+
+  /*!
+   * @brief Global general Add-on to Kodi callback functions
+   *
+   * To hold general functions not related to a instance type and usable for
+   * every add-on type.
+   *
+   * Related add-on header is "./xbmc/addons/kodi-addon-dev-kit/include/kodi/General.h"
+   */
+  struct Interface_General
+  {
+    static void Init(AddonGlobalInterface* interface);
+    static void DeInit(AddonGlobalInterface* interface);
+
+    /*!
+     * @brief callback functions from add-on to kodi
+     *
+     * @note For add of new functions use the "_" style to identify direct a
+     * add-on callback function. Everything with CamelCase is only for the
+     * usage in Kodi only.
+     *
+     * The parameter `kodiBase` is used to become the pointer for a `CAddonDll`
+     * class.
+     */
+    //@{
+    static bool get_setting(void* kodiBase, const char* settingName, void* settingValue);
+    static void open_settings_dialog(void* kodiBase);
+    //@}
+  };
+
+} /* extern "C" */
+} /* namespace ADDON */

--- a/xbmc/addons/interfaces/kodi/README.md
+++ b/xbmc/addons/interfaces/kodi/README.md
@@ -1,0 +1,8 @@
+Folder structure description
+----------------------
+
+This folder should be hold equal with the add-on headers on [dev-kit](../../kodi-addon-dev-kit/include/kodi) to make the view of relationship from them with Kodi specified to one place and in order to prevent a criss-crossing of one another.
+
+Everything related to add-on headers should only be present here and nowhere else.
+
+Here is the last place where Kodi structures and data should be used, everything on add-on must be complete independent from Kodi's internal parts.

--- a/xbmc/addons/interfaces/kodi/screensaver/CMakeLists.txt
+++ b/xbmc/addons/interfaces/kodi/screensaver/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(SOURCES Screensaver.cpp)
+
+set(HEADERS Screensaver.h)
+
+include_directories(${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include)
+
+core_add_library(addonInterface_kodi_screensaver)

--- a/xbmc/addons/interfaces/kodi/screensaver/Screensaver.cpp
+++ b/xbmc/addons/interfaces/kodi/screensaver/Screensaver.cpp
@@ -17,7 +17,9 @@
  *  <http://www.gnu.org/licenses/>.
  *
  */
-#include "ScreenSaver.h"
+
+#include "Screensaver.h"
+
 #include "ServiceBroker.h"
 #include "filesystem/SpecialProtocol.h"
 #include "guilib/GraphicContext.h"

--- a/xbmc/addons/interfaces/kodi/screensaver/Screensaver.h
+++ b/xbmc/addons/interfaces/kodi/screensaver/Screensaver.h
@@ -19,7 +19,7 @@
  *
  */
 
-#include "AddonDll.h"
+#include "addons/AddonDll.h"
 #include "addons/kodi-addon-dev-kit/include/kodi/screensaver/Screensaver.h"
 
 namespace ADDON

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
@@ -139,6 +139,7 @@ typedef ADDON_HANDLE_STRUCT *ADDON_HANDLE;
  * Callback function tables from addon to Kodi
  * Set complete from Kodi!
  */
+struct AddonToKodiFuncTable_kodi;
 typedef struct AddonToKodiFuncTable_Addon
 {
   // Pointer inside Kodi, used on callback functions to give related handle
@@ -150,6 +151,8 @@ typedef struct AddonToKodiFuncTable_Addon
   char* (*get_base_user_path)(void* kodiBase);
   void (*addon_log_msg)(void* kodiBase, const int loglevel, const char *msg);
   void (*free_string)(void* kodiBase, char* str);
+
+  AddonToKodiFuncTable_kodi* kodi;
 } AddonToKodiFuncTable_Addon;
 
 /*

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/General.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/General.h
@@ -1,0 +1,102 @@
+#pragma once
+/*
+ *      Copyright (C) 2005-2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with Kodi; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "AddonBase.h"
+
+extern "C"
+{
+
+/*
+ * For interface between add-on and kodi.
+ *
+ * In this structure becomes the addresses of functions inside Kodi stored who
+ * then available for the add-on to call.
+ *
+ * All function pointers there are used by the C++ interface functions below.
+ * You find the set of them on xbmc/addons/interfaces/kodi/General.cpp
+ *
+ * Note: For add-on development itself not needed, thats why with '*' here in
+ * text.
+ */
+typedef struct AddonToKodiFuncTable_kodi
+{
+  bool (*get_setting)(void* kodiBase, const char* settingName, void *settingValue);
+  void (*open_settings_dialog)(void* kodiBase);
+} AddonToKodiFuncTable_kodi;
+
+namespace kodi
+{
+  //============================================================================
+  ///
+  inline bool GetSettingString(const std::string& settingName, std::string& settingValue)
+  {
+    char * buffer = (char*) malloc(1024);
+    buffer[0] = 0; /* Set the end of string */
+    bool ret = ::kodi::addon::CAddonBase::m_interface->toKodi.kodi->get_setting(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, settingName.c_str(), buffer);
+    if (ret)
+      settingValue = buffer;
+    free(buffer);
+    return ret;
+  }
+  //----------------------------------------------------------------------------
+
+  //============================================================================
+  ///
+  inline bool GetSettingInt(const std::string& settingName, int& settingValue)
+  {
+    return ::kodi::addon::CAddonBase::m_interface->toKodi.kodi->get_setting(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, settingName.c_str(), &settingValue);
+  }
+  //----------------------------------------------------------------------------
+
+  //============================================================================
+  ///
+  inline bool GetSettingUInt(const std::string& settingName, unsigned int& settingValue)
+  {
+    return ::kodi::addon::CAddonBase::m_interface->toKodi.kodi->get_setting(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, settingName.c_str(), &settingValue);
+  }
+  //----------------------------------------------------------------------------
+
+  //============================================================================
+  ///
+  inline bool GetSettingBoolean(const std::string& settingName, bool& settingValue)
+  {
+    return ::kodi::addon::CAddonBase::m_interface->toKodi.kodi->get_setting(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, settingName.c_str(), &settingValue);
+  }
+  //----------------------------------------------------------------------------
+
+  //============================================================================
+  ///
+  inline bool GetSettingFloat(const std::string& settingName, float& settingValue)
+  {
+    return ::kodi::addon::CAddonBase::m_interface->toKodi.kodi->get_setting(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, settingName.c_str(), &settingValue);
+  }
+  //----------------------------------------------------------------------------
+
+  //============================================================================
+  ///
+  inline void OpenSettings()
+  {
+    ::kodi::addon::CAddonBase::m_interface->toKodi.kodi->open_settings_dialog(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase);
+  }
+  //----------------------------------------------------------------------------
+
+} /* namespace kodi */
+} /* extern "C" */

--- a/xbmc/windows/GUIWindowScreensaver.h
+++ b/xbmc/windows/GUIWindowScreensaver.h
@@ -21,7 +21,7 @@
  */
 
 #include "guilib/GUIWindow.h"
-#include "addons/ScreenSaver.h"
+#include "addons/interfaces/kodi/screensaver/Screensaver.h"
 
 #include "threads/CriticalSection.h"
 


### PR DESCRIPTION
This request add the initial part of the new used add-on library way for callbacks.
With the commit of them can be seen how a it can changed in future.

Further move the first commit the screensaver class files of Kodi to his final place.

@FernetMenta on second commit is the alternative to the old libXBMC_addon way to see :D