### PR TITLE
RetroPlayer: Remove use of private CDVDVideoCodec interface

### DIFF
--- a/xbmc/cores/RetroPlayer/RetroPlayerVideo.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayerVideo.h
@@ -25,7 +25,6 @@
 #include <memory>
 
 class CDVDClock;
-class CDVDVideoCodec;
 class CPixelConverter;
 class CProcessInfo;
 class CRenderManager;
@@ -68,6 +67,5 @@ namespace GAME
     bool         m_bConfigured; // Need first picture to configure the render manager
     unsigned int m_droppedFrames;
     std::unique_ptr<CPixelConverter> m_pixelConverter;
-    std::unique_ptr<CDVDVideoCodec>  m_pVideoCodec;
   };
 }


### PR DESCRIPTION
This is the first step in reimplementing video codecs in RetroPlayer.