### PR TITLE
RetroPlayer: fix compile fault

### DIFF
--- a/xbmc/cores/RetroPlayer/RetroPlayerVideo.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerVideo.cpp
@@ -80,6 +80,7 @@ bool CRetroPlayerVideo::OpenPixelStream(AVPixelFormat pixfmt, unsigned int width
 
 bool CRetroPlayerVideo::OpenEncodedStream(AVCodecID codec)
 {
+  /*
   CDemuxStreamVideo videoStream;
 
   // Stream
@@ -88,6 +89,7 @@ bool CRetroPlayerVideo::OpenEncodedStream(AVCodecID codec)
   videoStream.type = STREAM_VIDEO;
   videoStream.source = STREAM_SOURCE_DEMUX;
   videoStream.realtime = true;
+  */
 
   // Video
   //! @todo Needed?


### PR DESCRIPTION
This fix a compile fault who was come with https://github.com/FernetMenta/kodi-agile/pull/74

```
./kodi-agile/xbmc/cores/RetroPlayer/RetroPlayerVideo.cpp: In member function ‘virtual bool GAME::CRetroPlayerVideo::OpenEncodedStream(AVCodecID)’:
./kodi-agile/xbmc/cores/RetroPlayer/RetroPlayerVideo.cpp:83:3: error: ‘CDemuxStreamVideo’ was not declared in this scope
   CDemuxStreamVideo videoStream;
   ^
./kodi-agile/xbmc/cores/RetroPlayer/RetroPlayerVideo.cpp:86:3: error: ‘videoStream’ was not declared in this scope
   videoStream.uniqueId = GAME_STREAM_VIDEO_ID;
   ^
./kodi-agile/xbmc/cores/RetroPlayer/RetroPlayerVideo.cpp:88:22: error: ‘STREAM_VIDEO’ was not declared in this scope
   videoStream.type = STREAM_VIDEO;
                      ^
./kodi-agile/xbmc/cores/RetroPlayer/RetroPlayerVideo.cpp:89:24: error: ‘STREAM_SOURCE_DEMUX’ was not declared in this scope
   videoStream.source = STREAM_SOURCE_DEMUX;
                        ^
```

@FernetMenta @garbear was there a special reason to remove the include of them?