### PR TITLE
Change InputStreamCaps from multibool to bitmask

### DIFF
--- a/xbmc/addons/InputStream.h
+++ b/xbmc/addons/InputStream.h
@@ -55,11 +55,11 @@ namespace ADDON
     bool Open(CFileItem &fileitem);
     void Close();
 
-    bool HasDemux() { return m_caps.m_supportsIDemux; };
-    bool HasPosTime() { return m_caps.m_supportsIPosTime; };
-    bool HasDisplayTime() { return m_caps.m_supportsIDisplayTime; };
-    bool CanPause() { return m_caps.m_supportsPause; };
-    bool CanSeek() { return m_caps.m_supportsSeek; };
+    bool HasDemux() { return (m_caps.m_mask & INPUTSTREAM_CAPABILITIES::SUPPORTSIDEMUX) != 0; };
+    bool HasPosTime() { return (m_caps.m_mask & INPUTSTREAM_CAPABILITIES::SUPPORTSIPOSTIME) != 0; };
+    bool HasDisplayTime() { return (m_caps.m_mask & INPUTSTREAM_CAPABILITIES::SUPPORTSIDISPLAYTIME) != 0; };
+    bool CanPause() { return (m_caps.m_mask & INPUTSTREAM_CAPABILITIES::SUPPORTSPAUSE) != 0; };
+    bool CanSeek() { return (m_caps.m_mask & INPUTSTREAM_CAPABILITIES::SUPPORTSSEEK) != 0; };
 
     // IDisplayTime
     int GetTotalTime();

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_types.h
@@ -46,11 +46,26 @@ extern "C" {
    */
   typedef struct INPUTSTREAM_CAPABILITIES
   {
-    bool m_supportsIDemux;                  /*!< @brief supports interface IDemux */
-    bool m_supportsIPosTime;                /*!< @brief supports interface IPosTime */
-    bool m_supportsIDisplayTime;            /*!< @brief supports interface IDisplayTime */
-    bool m_supportsSeek;                    /*!< @brief supports seek */
-    bool m_supportsPause;                   /*!< @brief supports pause */
+    enum MASKTYPE: uint32_t
+    {
+      /// supports interface IDemux
+      SUPPORTSIDEMUX = (1 << 0),
+
+      /// supports interface IPosTime
+      SUPPORTSIPOSTIME = (1 << 1),
+
+      /// supports interface IDisplayTime
+      SUPPORTSIDISPLAYTIME = (1 << 2),
+
+      /// supports seek
+      SUPPORTSSEEK = (1 << 3),
+
+      /// supports pause
+      SUPPORTSPAUSE = (1 << 4)
+    };
+
+    /// set of supported capabilities
+    MASKTYPE m_mask;
   } INPUTSTREAM_CAPABILITIES;
 
   /*!


### PR DESCRIPTION
Having inputstream.capabilities as a set of bools has following disadvantages:

- Memory footprint
- processing performance
- each new capability forces an api change because of changed struct size
- resetting the mask is much easier than setting all elements to "false"

This list of bools is something wich hount me for long time, at least every time I strumble over it.
This PR gives me some minutes of sleep back :-)