### PR TITLE
[addons] fix windows build by prevent of 'interface' as value name

### DIFF
--- a/xbmc/addons/interfaces/kodi/General.cpp
+++ b/xbmc/addons/interfaces/kodi/General.cpp
@@ -35,19 +35,19 @@ using namespace kodi; // addon-dev-kit namespace
 namespace ADDON
 {
 
-void Interface_General::Init(AddonGlobalInterface* interface)
+void Interface_General::Init(AddonGlobalInterface* addonInterface)
 {
-  interface->toKodi.kodi = (AddonToKodiFuncTable_kodi*)malloc(sizeof(AddonToKodiFuncTable_kodi));
-  interface->toKodi.kodi->get_setting = get_setting;
-  interface->toKodi.kodi->open_settings_dialog = open_settings_dialog;
+  addonInterface->toKodi.kodi = (AddonToKodiFuncTable_kodi*)malloc(sizeof(AddonToKodiFuncTable_kodi));
+  addonInterface->toKodi.kodi->get_setting = get_setting;
+  addonInterface->toKodi.kodi->open_settings_dialog = open_settings_dialog;
 }
 
-void Interface_General::DeInit(AddonGlobalInterface* interface)
+void Interface_General::DeInit(AddonGlobalInterface* addonInterface)
 {
-  if (interface->toKodi.kodi)
+  if (addonInterface->toKodi.kodi)
   {
-    free(interface->toKodi.kodi);
-    interface->toKodi.kodi = nullptr;
+    free(addonInterface->toKodi.kodi);
+    addonInterface->toKodi.kodi = nullptr;
   }
 }
 

--- a/xbmc/addons/interfaces/kodi/General.h
+++ b/xbmc/addons/interfaces/kodi/General.h
@@ -20,11 +20,12 @@
  *
  */
 
+extern "C"
+{
+
 struct AddonGlobalInterface;
 
 namespace ADDON
-{
-extern "C"
 {
 
   /*!
@@ -37,8 +38,8 @@ extern "C"
    */
   struct Interface_General
   {
-    static void Init(AddonGlobalInterface* interface);
-    static void DeInit(AddonGlobalInterface* interface);
+    static void Init(AddonGlobalInterface* addonInterface);
+    static void DeInit(AddonGlobalInterface* addonInterface);
 
     /*!
      * @brief callback functions from add-on to kodi
@@ -56,5 +57,5 @@ extern "C"
     //@}
   };
 
-} /* extern "C" */
 } /* namespace ADDON */
+} /* extern "C" */


### PR DESCRIPTION
Crazy windows fault, a variable as 'interface' brings stupid compile
error messages.