### PR TITLE
[RBP] Fix up MMAL for ffmpeg 3.2 and kodi-agile

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
@@ -595,7 +595,7 @@ void CMMALVideo::Dispose()
   Reset();
 }
 
-int CMMALVideo::Decode(uint8_t* pData, int iSize, double dts, double pts)
+int CMMALVideo::AddData(uint8_t* pData, int iSize, double dts, double pts)
 {
   CSingleLock lock(m_sharedSection);
   //if (g_advancedSettings.CanLogComponent(LOGVIDEO))
@@ -604,70 +604,52 @@ int CMMALVideo::Decode(uint8_t* pData, int iSize, double dts, double pts)
 
   MMAL_BUFFER_HEADER_T *buffer;
   MMAL_STATUS_T status;
-  bool drain = (m_codecControlFlags & DVD_CODEC_CTRL_DRAIN) ? true : false;
-  bool send_eos = drain && !m_got_eos && m_packet_num_eos != m_packet_num;
-  // we don't get an EOS response if no packets have been sent
-  if (m_packet_num == 0)
-  {
-    send_eos = false;
-    m_got_eos = true;
-  }
+  assert(pData != nullptr && iSize > 0); // no longer valid
+
   if (m_pool)
     m_pool->Prime();
-  while (1)
+  while (iSize > 0)
   {
-     if (pData || send_eos)
-     {
-       // 500ms timeout
-       {
-         lock.Leave();
-         buffer = mmal_queue_timedwait(m_dec_input_pool->queue, 500);
-         if (!buffer)
-         {
-           CLog::Log(LOGERROR, "%s::%s - mmal_queue_get failed", CLASSNAME, __func__);
-           return VC_ERROR;
-         }
-         lock.Enter();
-       }
-       mmal_buffer_header_reset(buffer);
-       buffer->cmd = 0;
-       buffer->pts = pts == DVD_NOPTS_VALUE ? MMAL_TIME_UNKNOWN : pts;
-       buffer->dts = dts == DVD_NOPTS_VALUE ? MMAL_TIME_UNKNOWN : dts;
-       if (m_hints.ptsinvalid) buffer->pts = MMAL_TIME_UNKNOWN;
-       buffer->length = (uint32_t)iSize > buffer->alloc_size ? buffer->alloc_size : (uint32_t)iSize;
-       // set a flag so we can identify primary frames from generated frames (deinterlace)
-       buffer->flags = 0;
-       if (m_codecControlFlags & DVD_CODEC_CTRL_DROP_ANY)
-         buffer->flags |= MMAL_BUFFER_HEADER_FLAG_USER3;
-
-       if (pData)
-         memcpy(buffer->data, pData, buffer->length);
-       iSize -= buffer->length;
-       pData += buffer->length;
-
-       if (iSize == 0)
-       {
-         m_packet_num++;
-         buffer->flags |= MMAL_BUFFER_HEADER_FLAG_FRAME_END;
-         if (send_eos)
-         {
-           buffer->flags |= MMAL_BUFFER_HEADER_FLAG_EOS;
-           m_packet_num_eos = m_packet_num;
-           m_got_eos = false;
-         }
-       }
-       if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-         CLog::Log(LOGDEBUG, "%s::%s - %-8p %-6d/%-6d dts:%.3f pts:%.3f flags:%x ready_queue(%d)",
-            CLASSNAME, __func__, buffer, buffer->length, iSize, dts == DVD_NOPTS_VALUE ? 0.0 : dts*1e-6, pts == DVD_NOPTS_VALUE ? 0.0 : pts*1e-6, buffer->flags, m_output_ready.size());
-       status = mmal_port_send_buffer(m_dec_input, buffer);
-       if (status != MMAL_SUCCESS)
-       {
-         CLog::Log(LOGERROR, "%s::%s Failed send buffer to decoder input port (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
-         return VC_ERROR;
-       }
+    // 500ms timeout
+    lock.Leave();
+    buffer = mmal_queue_timedwait(m_dec_input_pool->queue, 500);
+    if (!buffer)
+    {
+      CLog::Log(LOGERROR, "%s::%s - mmal_queue_get failed", CLASSNAME, __func__);
+      return VC_ERROR;
     }
-    if (!iSize)
-      break;
+    lock.Enter();
+
+    mmal_buffer_header_reset(buffer);
+    buffer->cmd = 0;
+    buffer->pts = pts == DVD_NOPTS_VALUE ? MMAL_TIME_UNKNOWN : pts;
+    buffer->dts = dts == DVD_NOPTS_VALUE ? MMAL_TIME_UNKNOWN : dts;
+    if (m_hints.ptsinvalid) buffer->pts = MMAL_TIME_UNKNOWN;
+    buffer->length = (uint32_t)iSize > buffer->alloc_size ? buffer->alloc_size : (uint32_t)iSize;
+    // set a flag so we can identify primary frames from generated frames (deinterlace)
+    buffer->flags = 0;
+    if (m_codecControlFlags & DVD_CODEC_CTRL_DROP_ANY)
+      buffer->flags |= MMAL_BUFFER_HEADER_FLAG_USER3;
+
+    if (pData)
+      memcpy(buffer->data, pData, buffer->length);
+    iSize -= buffer->length;
+    pData += buffer->length;
+
+    if (iSize == 0)
+    {
+      m_packet_num++;
+      buffer->flags |= MMAL_BUFFER_HEADER_FLAG_FRAME_END;
+    }
+    if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+      CLog::Log(LOGDEBUG, "%s::%s - %-8p %-6d/%-6d dts:%.3f pts:%.3f flags:%x ready_queue(%d)",
+         CLASSNAME, __func__, buffer, buffer->length, iSize, dts == DVD_NOPTS_VALUE ? 0.0 : dts*1e-6, pts == DVD_NOPTS_VALUE ? 0.0 : pts*1e-6, buffer->flags, m_output_ready.size());
+    status = mmal_port_send_buffer(m_dec_input, buffer);
+    if (status != MMAL_SUCCESS)
+    {
+      CLog::Log(LOGERROR, "%s::%s Failed send buffer to decoder input port (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+      return VC_ERROR;
+    }
   }
   if (pts != DVD_NOPTS_VALUE)
     m_demuxerPts = pts;
@@ -677,35 +659,7 @@ int CMMALVideo::Decode(uint8_t* pData, int iSize, double dts, double pts)
   if (m_demuxerPts != DVD_NOPTS_VALUE && m_decoderPts == DVD_NOPTS_VALUE)
     m_decoderPts = m_demuxerPts;
 
-  // we've built up quite a lot of data in decoder - try to throttle it
-  double queued = m_decoderPts != DVD_NOPTS_VALUE && m_demuxerPts != DVD_NOPTS_VALUE ? m_demuxerPts - m_decoderPts : 0.0;
-  bool full = queued > DVD_MSEC_TO_TIME(1000);
-  int ret = 0;
-
-  XbmcThreads::EndTime delay(500);
-  while (!ret && !delay.IsTimePast())
-  {
-    CSingleLock output_lock(m_output_mutex);
-    unsigned int pics = m_output_ready.size();
-    if (m_preroll && (pics >= GetAllowedReferences() || drain))
-      m_preroll = false;
-    if (pics > 0 && !m_preroll)
-      ret |= VC_PICTURE;
-    if ((m_preroll || pics <= 1) && mmal_queue_length(m_dec_input_pool->queue) > 0 && (!drain || m_got_eos || m_packet_num_eos != m_packet_num))
-      ret |= VC_BUFFER;
-    if (!ret)
-    {
-      // otherwise we busy spin
-      lock.Leave();
-      m_output_cond.wait(output_lock, delay.MillisLeft());
-      lock.Enter();
-    }
-  }
-
-  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-    CLog::Log(LOGDEBUG, "%s::%s - ret(%x) pics(%d) inputs(%d) slept(%2d) queued(%.2f) (%.2f:%.2f) full(%d) flags(%x) preroll(%d) eos(%d %d/%d)", CLASSNAME, __func__, ret, m_output_ready.size(), mmal_queue_length(m_dec_input_pool->queue), 500-delay.MillisLeft(), queued*1e-6, m_demuxerPts*1e-6, m_decoderPts*1e-6, full, m_codecControlFlags,  m_preroll, m_got_eos, m_packet_num, m_packet_num_eos);
-
-  return ret;
+  return 0;
 }
 
 void CMMALVideo::Reset(void)
@@ -769,23 +723,87 @@ void CMMALVideo::SetSpeed(int iSpeed)
   m_speed = iSpeed;
 }
 
-bool CMMALVideo::GetPicture(DVDVideoPicture* pDvdVideoPicture)
+int CMMALVideo::GetPicture(DVDVideoPicture* pDvdVideoPicture)
 {
   CSingleLock lock(m_sharedSection);
+  MMAL_STATUS_T status;
+  bool drain = (m_codecControlFlags & DVD_CODEC_CTRL_DRAIN) ? true : false;
+  bool send_eos = drain && !m_got_eos && m_packet_num_eos != m_packet_num;
+
+  // we don't get an EOS response if no packets have been sent
+  if (m_packet_num == 0 && send_eos)
+    m_got_eos = true;
+
+  if (send_eos && !m_got_eos)
+  {
+    MMAL_BUFFER_HEADER_T *buffer;
+    // 500ms timeout
+    lock.Leave();
+    buffer = mmal_queue_timedwait(m_dec_input_pool->queue, 500);
+    lock.Enter();
+
+    if (buffer)
+    {
+      mmal_buffer_header_reset(buffer);
+      buffer->cmd = 0;
+      buffer->flags |= MMAL_BUFFER_HEADER_FLAG_FRAME_END | MMAL_BUFFER_HEADER_FLAG_EOS;
+      m_packet_num_eos = m_packet_num;
+      m_got_eos = false;
+      status = mmal_port_send_buffer(m_dec_input, buffer);
+      if (status != MMAL_SUCCESS)
+      {
+        CLog::Log(LOGERROR, "%s::%s Failed send buffer to decoder input port (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
+        return VC_ERROR;
+      }
+      else if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+        CLog::Log(LOGDEBUG, "%s::%s - Send EOS (%d, %d, %d)", CLASSNAME, __func__, m_got_eos, m_packet_num, m_packet_num_eos);
+    }
+    else
+    {
+      CLog::Log(LOGWARNING, "%s::%s - mmal_queue_get failed", CLASSNAME, __func__);
+      // lets assume decoder has returned all it will
+      m_got_eos = true;
+    }
+  }
+
+  // we've built up quite a lot of data in decoder - try to throttle it
+  double queued = m_decoderPts != DVD_NOPTS_VALUE && m_demuxerPts != DVD_NOPTS_VALUE ? m_demuxerPts - m_decoderPts : 0.0;
+  bool full = queued > DVD_MSEC_TO_TIME(1000);
+  int ret = 0;
+
   CMMALVideoBuffer *buffer = nullptr;
+  XbmcThreads::EndTime delay(500);
+  while (!ret && !delay.IsTimePast())
   {
     CSingleLock output_lock(m_output_mutex);
-    if (!m_output_ready.empty())
+    unsigned int pics = m_output_ready.size();
+    if (m_preroll && (pics >= GetAllowedReferences() || drain))
+      m_preroll = false;
+    if (pics > 0 && !m_preroll)
     {
       // fetch a output buffer and pop it off the ready list
       buffer = m_output_ready.front();
       m_output_ready.pop();
       m_output_cond.notifyAll();
+      ret = VC_PICTURE;
+    }
+    else if (m_got_eos)
+      ret = VC_EOF;
+    else if ((m_preroll || pics <= 1) && mmal_queue_length(m_dec_input_pool->queue) > 0)
+      ret = VC_BUFFER;
+    if (!ret)
+    {
+      // otherwise we busy spin
+      lock.Leave();
+      m_output_cond.wait(output_lock, delay.MillisLeft());
+      lock.Enter();
     }
   }
-  if (buffer)
+
+  if (ret == VC_PICTURE)
   {
-    assert(buffer->mmal_buffer);
+    ClearPicture(pDvdVideoPicture);
+    assert(buffer && buffer->mmal_buffer);
     memset(pDvdVideoPicture, 0, sizeof *pDvdVideoPicture);
     pDvdVideoPicture->format = RENDER_FMT_MMAL;
     pDvdVideoPicture->MMALBuffer = buffer;
@@ -822,13 +840,11 @@ bool CMMALVideo::GetPicture(DVDVideoPicture* pDvdVideoPicture)
     buffer->mmal_buffer->flags &= ~MMAL_BUFFER_HEADER_FLAG_USER3;
     buffer->m_stills = m_hints.stills;
   }
-  else
-  {
-    CLog::Log(LOGERROR, "%s::%s - called but m_output_ready is empty", CLASSNAME, __func__);
-    return false;
-  }
 
-  return true;
+  if (g_advancedSettings.CanLogComponent(LOGVIDEO))
+    CLog::Log(LOGDEBUG, "%s::%s - ret(%x) pics(%d) inputs(%d) slept(%2d) queued(%.2f) (%.2f:%.2f) full(%d) flags(%x) preroll(%d) eos(%d %d/%d)", CLASSNAME, __func__, ret, m_output_ready.size(), mmal_queue_length(m_dec_input_pool->queue), 500-delay.MillisLeft(), queued*1e-6, m_demuxerPts*1e-6, m_decoderPts*1e-6, full, m_codecControlFlags,  m_preroll, m_got_eos, m_packet_num, m_packet_num_eos);
+
+  return ret;
 }
 
 bool CMMALVideo::ClearPicture(DVDVideoPicture* pDvdVideoPicture)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
@@ -595,13 +595,6 @@ void CMMALVideo::Dispose()
   Reset();
 }
 
-void CMMALVideo::SetDropState(bool bDrop)
-{
-  if (bDrop != m_dropState)
-    CLog::Log(LOGDEBUG, "%s::%s - bDrop(%d)", CLASSNAME, __func__, bDrop);
-  m_dropState = bDrop;
-}
-
 int CMMALVideo::Decode(uint8_t* pData, int iSize, double dts, double pts)
 {
   CSingleLock lock(m_sharedSection);
@@ -644,7 +637,7 @@ int CMMALVideo::Decode(uint8_t* pData, int iSize, double dts, double pts)
        buffer->length = (uint32_t)iSize > buffer->alloc_size ? buffer->alloc_size : (uint32_t)iSize;
        // set a flag so we can identify primary frames from generated frames (deinterlace)
        buffer->flags = 0;
-       if (m_dropState)
+       if (m_codecControlFlags & DVD_CODEC_CTRL_DROP_ANY)
          buffer->flags |= MMAL_BUFFER_HEADER_FLAG_USER3;
 
        if (pData)
@@ -761,7 +754,6 @@ void CMMALVideo::Reset(void)
   m_decoderPts = DVD_NOPTS_VALUE;
   m_demuxerPts = DVD_NOPTS_VALUE;
   m_codecControlFlags = 0;
-  m_dropState = false;
   m_num_decoded = 0;
   m_got_eos = false;
   m_packet_num = 0;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
@@ -502,7 +502,7 @@ bool CMMALVideo::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
   if (status != MMAL_SUCCESS)
     CLog::Log(LOGERROR, "%s::%s Failed to disable error concealment on %s (status=%x %s)", CLASSNAME, __func__, m_dec_input->name, status, mmal_status_to_string(status));
 
-  status = mmal_port_parameter_set_uint32(m_dec_input, MMAL_PARAMETER_EXTRA_BUFFERS, GetAllowedReferences());
+  status = mmal_port_parameter_set_uint32(m_dec_input, MMAL_PARAMETER_EXTRA_BUFFERS, GetAllowedReferences()+1);
   if (status != MMAL_SUCCESS)
     CLog::Log(LOGERROR, "%s::%s Failed to enable extra buffers on %s (status=%x %s)", CLASSNAME, __func__, m_dec_input->name, status, mmal_status_to_string(status));
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
@@ -99,7 +99,6 @@ public:
   virtual bool GetPicture(DVDVideoPicture *pDvdVideoPicture);
   virtual bool ClearPicture(DVDVideoPicture* pDvdVideoPicture);
   virtual unsigned GetAllowedReferences() { return 4; }
-  virtual void SetDropState(bool bDrop);
   virtual const char* GetName(void) { return m_pFormatName ? m_pFormatName:"mmal-xxx"; }
   virtual bool GetCodecStats(double &pts, int &droppedPics);
   virtual void SetCodecControl(int flags);
@@ -143,7 +142,6 @@ protected:
   double            m_decoderPts;
   int               m_speed;
   int               m_codecControlFlags;
-  bool              m_dropState;
   bool              m_preroll;
   bool              m_got_eos;
   uint32_t          m_packet_num;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
@@ -94,9 +94,9 @@ public:
 
   // Required overrides
   virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options);
-  virtual int  Decode(uint8_t *pData, int iSize, double dts, double pts);
+  virtual int AddData(uint8_t *pData, int iSize, double dts, double pts);
   virtual void Reset(void);
-  virtual bool GetPicture(DVDVideoPicture *pDvdVideoPicture);
+  virtual int GetPicture(DVDVideoPicture *pDvdVideoPicture);
   virtual bool ClearPicture(DVDVideoPicture* pDvdVideoPicture);
   virtual unsigned GetAllowedReferences() { return 4; }
   virtual const char* GetName(void) { return m_pFormatName ? m_pFormatName:"mmal-xxx"; }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.h
@@ -56,7 +56,7 @@ public:
   virtual ~CDecoder();
   virtual bool Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum AVPixelFormat, unsigned int surfaces);
   virtual int Decode(AVCodecContext* avctx, AVFrame* frame);
-  virtual bool GetPicture(AVCodecContext* avctx, AVFrame* frame, DVDVideoPicture* picture);
+  virtual bool GetPicture(AVCodecContext* avctx, DVDVideoPicture* picture);
   virtual int Check(AVCodecContext* avctx);
   virtual void Close();
   virtual const std::string Name() { return "mmal"; }
@@ -74,6 +74,7 @@ protected:
   std::shared_ptr<CMMALPool> m_pool;
   enum AVPixelFormat m_fmt;
   CDVDStreamInfo m_hints;
+  CGPUMEM *m_gmem;
 };
 
 };

--- a/xbmc/cores/omxplayer/OMXAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXAudio.cpp
@@ -38,7 +38,7 @@
 #include "settings/MediaSettings.h"
 #include "settings/Settings.h"
 #include "guilib/LocalizeStrings.h"
-#include "cores/AudioEngine/AEFactory.h"
+//#include "cores/AudioEngine/AEFactory.h"
 #include "Util.h"
 #include <algorithm>
 #include <cassert>
@@ -94,16 +94,16 @@ COMXAudio::COMXAudio() :
   m_failed_eos      (false  ),
   m_output          (AESINKPI_UNKNOWN)
 {
-  CAEFactory::Suspend();
-  while (!CAEFactory::IsSuspended())
-    Sleep(10);
+  //CAEFactory::Suspend();
+  //while (!CAEFactory::IsSuspended())
+  //  Sleep(10);
 }
 
 COMXAudio::~COMXAudio()
 {
   Deinitialize();
 
-  CAEFactory::Resume();
+  //CAEFactory::Resume();
 }
 
 bool COMXAudio::PortSettingsChanged()
@@ -602,7 +602,7 @@ bool COMXAudio::Initialize(AEAudioFormat format, OMXClock *clock, CDVDStreamInfo
     CAEChannelInfo resolvedMap = channelMap;
     resolvedMap.ResolveChannels(stdLayout);
 
-    if (CServiceBroker::GetSettings().GetInt(CSettings::SETTING_AUDIOOUTPUT_CONFIG) == AE_CONFIG_FIXED || (upmix && channelMap.Count() <= 2))
+    if (CServiceBroker::GetSettings().GetInt(CSettings::SETTING_AUDIOOUTPUT_CONFIG) == 1 /*AE_CONFIG_FIXED*/ || (upmix && channelMap.Count() <= 2))
       resolvedMap = stdLayout;
 
     uint64_t m_dst_chan_layout = GetAVChannelLayout(resolvedMap);

--- a/xbmc/cores/omxplayer/OMXAudioCodecOMX.cpp
+++ b/xbmc/cores/omxplayer/OMXAudioCodecOMX.cpp
@@ -25,7 +25,7 @@
 #include "utils/log.h"
 
 #include "cores/AudioEngine/Utils/AEUtil.h"
-#include "cores/AudioEngine/AEFactory.h"
+//#include "cores/AudioEngine/AEFactory.h"
 #include "settings/Settings.h"
 #include "linux/RBP.h"
 
@@ -95,6 +95,7 @@ bool COMXAudioCodecOMX::Open(CDVDStreamInfo &hints)
   m_pCodecContext->block_align = hints.blockalign;
   m_pCodecContext->bit_rate = hints.bitrate;
   m_pCodecContext->bits_per_coded_sample = hints.bitspersample;
+#if 0
   if (hints.codec == AV_CODEC_ID_TRUEHD)
   {
     if (CAEFactory::HasStereoAudioChannelCount())
@@ -102,6 +103,7 @@ bool COMXAudioCodecOMX::Open(CDVDStreamInfo &hints)
     else if (!CAEFactory::HasHDAudioChannelCount())
       m_pCodecContext->request_channel_layout = AV_CH_LAYOUT_5POINT1;
   }
+#endif
   if (m_pCodecContext->request_channel_layout)
     CLog::Log(LOGNOTICE,"COMXAudioCodecOMX::Open() Requesting channel layout of %x", (unsigned)m_pCodecContext->request_channel_layout);
 

--- a/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
+++ b/xbmc/cores/omxplayer/OMXPlayerAudio.cpp
@@ -39,7 +39,7 @@
 #include "utils/TimeUtils.h"
 
 #include "linux/RBP.h"
-#include "cores/AudioEngine/AEFactory.h"
+//#include "cores/AudioEngine/AEFactory.h"
 #include "cores/DataCacheCore.h"
 #include "ServiceBroker.h"
 
@@ -532,12 +532,12 @@ AEAudioFormat OMXPlayerAudio::GetDataFormat(CDVDStreamInfo hints)
       format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_NULL;
   }
 
-  m_passthrough = CAEFactory::SupportsRaw(format);
+  m_passthrough = true; //CAEFactory::SupportsRaw(format);
 
   if (!m_passthrough && hints.codec == AV_CODEC_ID_DTS)
   {
     format.m_streamInfo.m_type = CAEStreamInfo::STREAM_TYPE_DTSHD_CORE;
-    m_passthrough = CAEFactory::SupportsRaw(format);
+    m_passthrough = true; //CAEFactory::SupportsRaw(format);
   }
 
   if(!m_passthrough)


### PR DESCRIPTION
With just the ffmpeg 3.2 changes and excluding omxplayer commit all seems good on pi (I've tested on last couple of milhouse builds).

The subsequent AE changes break omxplayer, so that will need more work - I've just hacked it so it builds (but doesn't work).

One issue is I need to allocate an extra picture buffer on GPU compared to kodi master.
That only seems necessary with live TV (e.g. tvheadend), but not for similar interlaced video files.
That suggests renderer is now holding onto amn additional picture.
Is that a known change? It would be nice to avoid or at least understand that.