### PR TITLE
[addons] improve add-on interface settings handling

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -276,6 +276,12 @@ void CAddon::UpdateSetting(const std::string& key, const std::string& value)
   m_settings[key] = value;
 }
 
+void CAddon::UpdateSettings(std::map<std::string, std::string>& settings)
+{
+  LoadSettings();
+  m_settings = settings;
+}
+
 bool CAddon::SettingsFromXML(const CXBMCTinyXML &doc, bool loadDefaults /*=false */)
 {
   if (!doc.RootElement())

--- a/xbmc/addons/Addon.h
+++ b/xbmc/addons/Addon.h
@@ -145,6 +145,8 @@ public:
    */
   void UpdateSetting(const std::string& key, const std::string& value) override;
 
+  virtual void UpdateSettings(std::map<std::string, std::string>& settings);
+
   /*! \brief Retrieve a particular settings value
    If a previously configured user setting is available, we return it's value, else we return the default (if available)
    \param key the id of the setting to retrieve

--- a/xbmc/addons/AddonDll.cpp
+++ b/xbmc/addons/AddonDll.cpp
@@ -62,7 +62,7 @@ CAddonDll::CAddonDll(const CAddonDll &rhs)
   m_pHelpers          = rhs.m_pHelpers;
   m_needsavedsettings = rhs.m_needsavedsettings;
   m_parentLib = rhs.m_parentLib;
-  memset(&m_interface, 0, sizeof(m_interface));
+  m_interface = rhs.m_interface;
 }
 
 CAddonDll::~CAddonDll()
@@ -611,6 +611,16 @@ ADDON_STATUS CAddonDll::TransferSettings()
   }
 
   return ADDON_STATUS_OK;
+}
+
+void CAddonDll::UpdateSettings(std::map<std::string, std::string>& settings)
+{
+  if (m_interface.toAddon.set_setting)
+  {
+    for (auto it = settings.begin(); it != settings.end(); ++it)
+      m_interface.toAddon.set_setting(it->first.c_str(), it->second.c_str(), (std::next(it) == settings.end()) ? true : false);
+  }
+  CAddon::UpdateSettings(settings);
 }
 
 /*!

--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -55,6 +55,8 @@ namespace ADDON
     ADDON_STATUS CreateInstance(int instanceType, const std::string& instanceID, KODI_HANDLE instance, KODI_HANDLE* addonInstance);
     void DestroyInstance(const std::string& instanceID);
 
+    virtual void UpdateSettings(std::map<std::string, std::string>& settings);
+
   protected:
     bool Initialized() { return m_initialized; }
     virtual bool LoadSettings();

--- a/xbmc/addons/GUIDialogAddonSettings.cpp
+++ b/xbmc/addons/GUIDialogAddonSettings.cpp
@@ -558,9 +558,7 @@ void CGUIDialogAddonSettings::UpdateFromControls()
 void CGUIDialogAddonSettings::SaveSettings(void)
 {
   UpdateFromControls();
-
-  for (std::map<std::string, std::string>::iterator i = m_settings.begin(); i != m_settings.end(); ++i)
-    m_addon->UpdateSetting(i->first, i->second);
+  m_addon->UpdateSettings(m_settings);
 
   if (m_saveToDisk)
   { 

--- a/xbmc/addons/IAddon.h
+++ b/xbmc/addons/IAddon.h
@@ -124,6 +124,7 @@ namespace ADDON
     virtual bool HasSettings() =0;
     virtual void SaveSettings() =0;
     virtual void UpdateSetting(const std::string& key, const std::string& value) =0;
+    virtual void UpdateSettings(std::map<std::string, std::string>& settings) =0;
     virtual std::string GetSetting(const std::string& key) =0;
     virtual TiXmlElement* GetSettingsXML() =0;
     virtual const ADDONDEPS &GetDeps() const =0;

--- a/xbmc/addons/interfaces/kodi/General.h
+++ b/xbmc/addons/interfaces/kodi/General.h
@@ -53,6 +53,7 @@ namespace ADDON
      */
     //@{
     static bool get_setting(void* kodiBase, const char* settingName, void* settingValue);
+    static bool set_setting(void* kodiBase, const char* settingName, const char* settingValue);
     static void open_settings_dialog(void* kodiBase);
     //@}
   };

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
@@ -160,7 +160,7 @@ typedef struct AddonToKodiFuncTable_Addon
  */
 typedef struct KodiToAddonFuncTable_Addon
 {
-  void* dummy;
+  ADDON_STATUS (*set_setting)(const char *settingName, const void *settingValue, bool lastSetting);
 } KodiToAddonFuncTable_Addon;
 
 /*
@@ -195,6 +195,8 @@ typedef struct AddonGlobalInterface
   // Set from addon header!
   KodiToAddonFuncTable_Addon toAddon;
 } AddonGlobalInterface;
+
+} /* extern "C" */
 
 namespace kodi {
 namespace addon {
@@ -256,6 +258,21 @@ namespace addon {
   //
   //=-----=------=------=------=------=------=------=------=------=------=-----=
 
+  class CSettingValue
+  {
+  public:
+    CSettingValue(const void *settingValue) : m_settingValue(settingValue) {}
+
+    bool empty() const { return (m_settingValue == nullptr) ? true : false; }
+    std::string GetString() const { return (char*)m_settingValue; }
+    int GetInt() const { return *(int*)m_settingValue; }
+    unsigned int GetUInt() const { return *(unsigned int*)m_settingValue; }
+    bool GetBool() const { return *(bool*)m_settingValue; }
+    float GetFloat() const { return *(float*)m_settingValue; }
+
+  private:
+    const void *m_settingValue;
+  };
 
   //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   // Function used on Kodi itself to transfer back from add-on given data with
@@ -296,6 +313,7 @@ namespace addon {
   public:
     CAddonBase()
     {
+      CAddonBase::m_interface->toAddon.set_setting = ADDONBASE_SetSetting;
     }
 
     virtual ~CAddonBase()
@@ -310,7 +328,7 @@ namespace addon {
 
     virtual bool GetSettings(std::vector<CAddonSetting>& settings) { return false; }
 
-    virtual ADDON_STATUS SetSetting(const std::string& settingName, const void *settingValue) { return ADDON_STATUS_UNKNOWN; }
+    virtual ADDON_STATUS SetSetting(const std::string& settingName, const CSettingValue& settingValue, bool lastSetting) { return ADDON_STATUS_UNKNOWN; }
 
     virtual ADDON_STATUS CreateInstance(int instanceType, std::string instanceID, KODI_HANDLE instance, KODI_HANDLE& addonInstance)
     {
@@ -389,10 +407,9 @@ namespace addon {
       return 0;
     }
 
-    static inline ADDON_STATUS ADDONBASE_SetSetting(const char *settingName, const void *settingValue)
+    static inline ADDON_STATUS ADDONBASE_SetSetting(const char *settingName, const void *settingValue, bool lastSetting)
     {
-      std::string name = settingName;
-      return CAddonBase::m_interface->addonBase->SetSetting(name, settingValue);
+      return CAddonBase::m_interface->addonBase->SetSetting(settingName, CSettingValue(settingValue), lastSetting);
     }
 
     static inline void ADDONBASE_FreeSettings(unsigned int elements, ADDON_StructSetting*** set)
@@ -497,7 +514,6 @@ inline void Log(const AddonLog loglevel, const char* format, ...)
 } /* namespace kodi */
 //------------------------------------------------------------------------------
 
-} /* extern "C" */
 
 
 /*! addon creation macro
@@ -536,10 +552,7 @@ inline void Log(const AddonLog loglevel, const char* format, ...)
   { \
     kodi::addon::CAddonBase::ADDONBASE_FreeSettings(0, nullptr); /* Currently bad but becomes soon changed! */ \
   } \
-  extern "C" __declspec(dllexport) ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue) \
-  { \
-    return kodi::addon::CAddonBase::ADDONBASE_SetSetting(settingName, settingValue); \
-  } \
+  extern "C" __declspec(dllexport) ADDON_STATUS ADDON_SetSetting(const char *settingName, const void *settingValue) { return ADDON_STATUS_OK; } \
   extern "C" __declspec(dllexport) const char* ADDON_GetTypeVersion(int type) \
   { \
     return kodi::addon::GetTypeVersion(type); \

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/General.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/General.h
@@ -39,6 +39,7 @@ extern "C"
 typedef struct AddonToKodiFuncTable_kodi
 {
   bool (*get_setting)(void* kodiBase, const char* settingName, void *settingValue);
+  bool (*set_setting)(void* kodiBase, const char* settingName, const char* settingValue);
   void (*open_settings_dialog)(void* kodiBase);
 } AddonToKodiFuncTable_kodi;
 
@@ -72,6 +73,14 @@ namespace kodi
 
   //============================================================================
   ///
+  inline void SetSettingString(const std::string& settingName, const std::string& settingValue)
+  {
+    ::kodi::addon::CAddonBase::m_interface->toKodi.kodi->set_setting(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, settingName.c_str(), settingValue.c_str());
+  }
+  //----------------------------------------------------------------------------
+
+  //============================================================================
+  ///
   inline bool CheckSettingInt(const std::string& settingName, int& settingValue)
   {
     return ::kodi::addon::CAddonBase::m_interface->toKodi.kodi->get_setting(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, settingName.c_str(), &settingValue);
@@ -90,19 +99,11 @@ namespace kodi
 
   //============================================================================
   ///
-  inline bool CheckSettingUInt(const std::string& settingName, unsigned int& settingValue)
+  inline void SetSettingInt(const std::string& settingName, int settingValue)
   {
-    return ::kodi::addon::CAddonBase::m_interface->toKodi.kodi->get_setting(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, settingName.c_str(), &settingValue);
-  }
-  //----------------------------------------------------------------------------
-
-  //============================================================================
-  ///
-  inline unsigned int GetSettingUInt(const std::string& settingName)
-  {
-    unsigned int settingValue = 0;
-    CheckSettingUInt(settingName, settingValue);
-    return settingValue;
+    char buffer[33];
+    snprintf(buffer, sizeof(buffer), "%i", settingValue);
+    ::kodi::addon::CAddonBase::m_interface->toKodi.kodi->set_setting(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, settingName.c_str(), buffer);
   }
   //----------------------------------------------------------------------------
 
@@ -126,6 +127,14 @@ namespace kodi
 
   //============================================================================
   ///
+  inline void SetSettingBoolean(const std::string& settingName, bool settingValue)
+  {
+    ::kodi::addon::CAddonBase::m_interface->toKodi.kodi->set_setting(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, settingName.c_str(), settingValue ? "true" : "false");
+  }
+  //----------------------------------------------------------------------------
+
+  //============================================================================
+  ///
   inline bool CheckSettingFloat(const std::string& settingName, float& settingValue)
   {
     return ::kodi::addon::CAddonBase::m_interface->toKodi.kodi->get_setting(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, settingName.c_str(), &settingValue);
@@ -139,6 +148,16 @@ namespace kodi
     float settingValue = 0.0f;
     CheckSettingFloat(settingName, settingValue);
     return settingValue;
+  }
+  //----------------------------------------------------------------------------
+
+  //============================================================================
+  ///
+  inline void SetSettingFloat(const std::string& settingName, float settingValue)
+  {
+    char buffer[50];
+    snprintf(buffer, sizeof(buffer), "%f", settingValue);
+    ::kodi::addon::CAddonBase::m_interface->toKodi.kodi->set_setting(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, settingName.c_str(), buffer);
   }
   //----------------------------------------------------------------------------
 


### PR DESCRIPTION
Included changes makes the access of values on "SetSetting(...)" call
a bit easier to access.

Further is the settings set improved but due to duplicate use of CAddon Classes
currently not direct usable.