### PR TITLE
[addons] rework steps

### DIFF
--- a/cmake/treedata/common/subdirs.txt
+++ b/cmake/treedata/common/subdirs.txt
@@ -12,6 +12,7 @@ xbmc/addons/interfaces/PVR                      addonCallbacks_PVR
 xbmc/addons/interfaces/kodi                     addonInterface_kodi
 xbmc/addons/interfaces/kodi/screensaver         addonInterface_kodi_screensaver
 xbmc/addons/interfaces/kodi/visualization       addonInterface_kodi_visualization
+xbmc/addons/interfaces/kodi/gui                 addonInterface_kodi_gui
 xbmc/commons                                    commons
 xbmc/dbwrappers                                 dbwrappers
 xbmc/dialogs                                    dialogs

--- a/xbmc/addons/AddonDll.cpp
+++ b/xbmc/addons/AddonDll.cpp
@@ -37,6 +37,7 @@
  * Standard addon interface function includes
  */
 #include "addons/interfaces/kodi/General.h"
+#include "addons/interfaces/kodi/gui/General.h"
 
 namespace ADDON
 {
@@ -650,6 +651,7 @@ bool CAddonDll::InitInterface(KODI_HANDLE firstKodiInstance)
   m_interface.toKodi.free_string = free_string;
 
   Interface_General::Init(&m_interface);
+  Interface_GUIGeneral::Init(&m_interface);
 
   return true;
 }

--- a/xbmc/addons/interfaces/kodi/General.cpp
+++ b/xbmc/addons/interfaces/kodi/General.cpp
@@ -23,6 +23,7 @@
 
 #include "addons/kodi-addon-dev-kit/include/kodi/General.h"
 
+#include "Application.h"
 #include "GUIUserMessages.h"
 #include "ServiceBroker.h"
 #include "addons/AddonDll.h"
@@ -43,6 +44,7 @@ void Interface_General::Init(AddonGlobalInterface* addonInterface)
   addonInterface->toKodi.kodi->get_setting = get_setting;
   addonInterface->toKodi.kodi->set_setting = set_setting;
   addonInterface->toKodi.kodi->open_settings_dialog = open_settings_dialog;
+  addonInterface->toKodi.kodi->get_localized_string = get_localized_string;
 }
 
 void Interface_General::DeInit(AddonGlobalInterface* addonInterface)
@@ -183,6 +185,28 @@ void Interface_General::open_settings_dialog(void* kodiBase)
 
   // show settings dialog
   CGUIDialogAddonSettings::ShowAndGetInput(ADDON::AddonPtr(addon));
+}
+
+char* Interface_General::get_localized_string(void* kodiInstance, long dwCode)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiInstance);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "kodi::General::%s - invalid data (addon='%p')", __FUNCTION__, addon);
+    return nullptr;
+  }
+
+  if (g_application.m_bStop)
+    return nullptr;
+
+  std::string string;
+  if ((dwCode >= 30000 && dwCode <= 30999) || (dwCode >= 32000 && dwCode <= 32999))
+    string = g_localizeStrings.GetAddonString(addon->ID(), dwCode).c_str();
+  else
+    string = g_localizeStrings.Get(dwCode).c_str();
+
+  char* buffer = strdup(string.c_str());
+  return buffer;
 }
 
 } /* namespace ADDON */

--- a/xbmc/addons/interfaces/kodi/General.cpp
+++ b/xbmc/addons/interfaces/kodi/General.cpp
@@ -1,6 +1,6 @@
 /*
  *      Copyright (C) 2012-2013 Team XBMC
- *      Copyright (C) 2015-2016 Team KODI
+ *      Copyright (C) 2015-2017 Team KODI
  *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/xbmc/addons/interfaces/kodi/General.h
+++ b/xbmc/addons/interfaces/kodi/General.h
@@ -55,6 +55,7 @@ namespace ADDON
     static bool get_setting(void* kodiBase, const char* settingName, void* settingValue);
     static bool set_setting(void* kodiBase, const char* settingName, const char* settingValue);
     static void open_settings_dialog(void* kodiBase);
+    static char* get_localized_string(void* kodiBase, long dwCode);
     //@}
   };
 

--- a/xbmc/addons/interfaces/kodi/gui/CMakeLists.txt
+++ b/xbmc/addons/interfaces/kodi/gui/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(SOURCES General.cpp
+            DialogOK.cpp)
+
+set(HEADERS General.h
+            DialogOK.h)
+
+core_add_library(addonInterface_kodi_gui)

--- a/xbmc/addons/interfaces/kodi/gui/DialogOK.cpp
+++ b/xbmc/addons/interfaces/kodi/gui/DialogOK.cpp
@@ -1,0 +1,67 @@
+/*
+ *      Copyright (C) 2015-2016 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DialogOK.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/gui/DialogOK.h"
+
+#include "addons/AddonDll.h"
+#include "dialogs/GUIDialogOK.h"
+#include "utils/log.h"
+#include "utils/Variant.h"
+
+extern "C"
+{
+namespace ADDON
+{
+
+void Interface_GUIDialogOK::Init(AddonGlobalInterface* addonInterface)
+{
+  addonInterface->toKodi.kodi_gui->dialogOK.show_and_get_input_single_text = show_and_get_input_single_text;
+  addonInterface->toKodi.kodi_gui->dialogOK.show_and_get_input_line_text = show_and_get_input_line_text;
+}
+
+void Interface_GUIDialogOK::show_and_get_input_single_text(void* kodiBase, const char *heading, const char *text)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "kodi::gui::DialogOK:%s - invalid data (addon='%p', heading='%p', text='%p')",
+                                        __FUNCTION__, addon, heading, text);
+    return;
+  }
+
+  CGUIDialogOK::ShowAndGetInput(CVariant{heading}, CVariant{text});
+}
+
+void Interface_GUIDialogOK::show_and_get_input_line_text(void* kodiBase, const char *heading, const char *line0, const char *line1, const char *line2)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "kodi::gui::DialogOK::%s - invalid data (addon='%p', heading='%p', line0='%p', line1='%p', line2='%p')",
+                                        __FUNCTION__, addon, heading, line0, line1, line2);
+    return;
+  }
+
+  CGUIDialogOK::ShowAndGetInput(CVariant{heading}, CVariant{line0}, CVariant{line1}, CVariant{line2});
+}
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/kodi/gui/DialogOK.h
+++ b/xbmc/addons/interfaces/kodi/gui/DialogOK.h
@@ -1,0 +1,51 @@
+#pragma once
+/*
+ *      Copyright (C) 2015-2016 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+extern "C"
+{
+
+struct AddonGlobalInterface;
+
+namespace ADDON
+{
+
+  struct Interface_GUIDialogOK
+  {
+    static void Init(AddonGlobalInterface* addonInterface);
+
+    /*!
+     * @brief callback functions from add-on to kodi
+     *
+     * @note For add of new functions use the "_" style to identify direct a
+     * add-on callback function. Everything with CamelCase is only for the
+     * usage in Kodi only.
+     *
+     * The parameter `kodiBase` is used to become the pointer for a `CAddonDll`
+     * class.
+     */
+    //@{
+    static void show_and_get_input_single_text(void* kodiBase, const char *heading, const char *text);
+    static void show_and_get_input_line_text(void* kodiBase, const char *heading, const char *line0, const char *line1, const char *line2);
+    //@}
+  };
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/kodi/gui/General.cpp
+++ b/xbmc/addons/interfaces/kodi/gui/General.cpp
@@ -1,0 +1,153 @@
+/*
+ *      Copyright (C) 2015-2016 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "General.h"
+#include "DialogOK.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/gui/General.h"
+
+#include "addons/AddonDll.h"
+#include "guilib/GUIWindowManager.h"
+#include "utils/log.h"
+
+using namespace kodi; // addon-dev-kit namespace
+using namespace kodi::gui; // addon-dev-kit namespace
+
+namespace ADDON
+{
+int Interface_GUIGeneral::m_iAddonGUILockRef = 0;
+};
+
+extern "C"
+{
+
+namespace ADDON
+{
+
+void Interface_GUIGeneral::Init(AddonGlobalInterface* addonInterface)
+{
+  addonInterface->toKodi.kodi_gui = (AddonToKodiFuncTable_kodi_gui*)malloc(sizeof(AddonToKodiFuncTable_kodi_gui));
+  addonInterface->toKodi.kodi_gui->general.lock = lock;
+  addonInterface->toKodi.kodi_gui->general.unlock = unlock;
+  addonInterface->toKodi.kodi_gui->general.get_screen_height = get_screen_height;
+  addonInterface->toKodi.kodi_gui->general.get_screen_width = get_screen_width;
+  addonInterface->toKodi.kodi_gui->general.get_video_resolution = get_video_resolution;
+  addonInterface->toKodi.kodi_gui->general.get_current_window_dialog_id = get_current_window_dialog_id;
+  addonInterface->toKodi.kodi_gui->general.get_current_window_id = get_current_window_id;
+
+  Interface_GUIDialogOK::Init(addonInterface);
+}
+
+void Interface_GUIGeneral::DeInit(AddonGlobalInterface* addonInterface)
+{
+  if (addonInterface->toKodi.kodi_gui)
+  {
+    free(addonInterface->toKodi.kodi_gui);
+    addonInterface->toKodi.kodi_gui = nullptr;
+  }
+}
+
+//@{
+void Interface_GUIGeneral::lock()
+{
+  if (m_iAddonGUILockRef == 0)
+    g_graphicsContext.Lock();
+  ++m_iAddonGUILockRef;
+}
+
+void Interface_GUIGeneral::unlock()
+{
+  if (m_iAddonGUILockRef > 0)
+  {
+    --m_iAddonGUILockRef;
+    if (m_iAddonGUILockRef == 0)
+      g_graphicsContext.Unlock();
+  }
+}
+//@}
+
+//@{
+int Interface_GUIGeneral::get_screen_height(void* kodiBase)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "kodi::gui::%s - invalid data", __FUNCTION__);
+    return -1;
+  }
+
+  return g_graphicsContext.GetHeight();
+}
+
+int Interface_GUIGeneral::get_screen_width(void* kodiBase)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "kodi::gui::%s - invalid data", __FUNCTION__);
+    return -1;
+  }
+
+  return g_graphicsContext.GetWidth();
+}
+
+int Interface_GUIGeneral::get_video_resolution(void* kodiBase)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "kodi::gui::%s - invalid data", __FUNCTION__);
+    return -1;
+  }
+
+  return (int)g_graphicsContext.GetVideoResolution();
+}
+//@}
+
+//@{
+int Interface_GUIGeneral::get_current_window_dialog_id(void* kodiBase)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "kodi::gui::%s - invalid data", __FUNCTION__);
+    return -1;
+  }
+
+  CSingleLock gl(g_graphicsContext);
+  return g_windowManager.GetTopMostModalDialogID();
+}
+
+int Interface_GUIGeneral::get_current_window_id(void* kodiBase)
+{
+  CAddonDll* addon = static_cast<CAddonDll*>(kodiBase);
+  if (!addon)
+  {
+    CLog::Log(LOGERROR, "kodi::gui::%s - invalid data", __FUNCTION__);
+    return -1;
+  }
+
+  CSingleLock gl(g_graphicsContext);
+  return g_windowManager.GetActiveWindow();
+}
+
+//@}
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/interfaces/kodi/gui/General.h
+++ b/xbmc/addons/interfaces/kodi/gui/General.h
@@ -1,0 +1,69 @@
+#pragma once
+/*
+ *      Copyright (C) 2015-2016 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+extern "C"
+{
+
+struct AddonGlobalInterface;
+
+namespace ADDON
+{
+
+  /*!
+   * @brief Global gui Add-on to Kodi callback functions
+   *
+   * To hold general gui functions and initialize also all other gui related types not
+   * related to a instance type and usable for every add-on type.
+   *
+   * Related add-on header is "./xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/General.h"
+   */
+  struct Interface_GUIGeneral
+  {
+    static void Init(AddonGlobalInterface* addonInterface);
+    static void DeInit(AddonGlobalInterface* addonInterface);
+
+    /*!
+     * @brief callback functions from add-on to kodi
+     *
+     * @note For add of new functions use the "_" style to identify direct a
+     * add-on callback function. Everything with CamelCase is only for the
+     * usage in Kodi only.
+     *
+     * The parameter `kodiBase` is used to become the pointer for a `CAddonDll`
+     * class.
+     */
+    //@{
+    static void lock();
+    static void unlock();
+
+    static int get_screen_height(void* kodiBase);
+    static int get_screen_width(void* kodiBase);
+    static int get_video_resolution(void* kodiBase);
+    static int get_current_window_dialog_id(void* kodiBase);
+    static int get_current_window_id(void* kodiBase);
+    //@}
+
+  private:
+    static int m_iAddonGUILockRef;
+  };
+
+} /* namespace ADDON */
+} /* extern "C" */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *      Copyright (C) 2005-2016 Team Kodi
+ *      Copyright (C) 2005-2017 Team Kodi
  *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -38,6 +38,9 @@
 #endif
 
 #include "versions.h"
+
+namespace kodi { namespace addon { class CAddonBase; }}
+namespace kodi { namespace addon { class IAddonInstance; }}
 
 extern "C" {
 
@@ -167,8 +170,6 @@ typedef struct KodiToAddonFuncTable_Addon
  * Main structure passed from kodi to addon with basic information needed to
  * create add-on.
  */
-namespace kodi { namespace addon { class CAddonBase; }}
-namespace kodi { namespace addon { class IAddonInstance; }}
 typedef struct AddonGlobalInterface
 {
   // String with full path where add-on is installed (without his name on end)
@@ -198,81 +199,85 @@ typedef struct AddonGlobalInterface
 
 } /* extern "C" */
 
+//==============================================================================
 namespace kodi {
 namespace addon {
+/*
+ * Internal class to control various instance types with general parts defined
+ * here.
+ *
+ * Mainly is this currently used to identify requested instance types.
+ *
+ * @note This class is not need to know during add-on development thats why
+ * with "/*".
+ */
+class IAddonInstance
+{
+public:
+  IAddonInstance(ADDON_TYPE type) : m_type(type) { }
+  virtual ~IAddonInstance() { }
 
-  //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-  //
-  class IAddonInstance
+  const ADDON_TYPE m_type;
+};
+} /* namespace addon */
+} /* namespace kodi */
+//------------------------------------------------------------------------------
+
+//==============================================================================
+namespace kodi {
+/// 
+class CSettingValue
+{
+public:
+  CSettingValue(const void *settingValue) : m_settingValue(settingValue) {}
+
+  bool empty() const { return (m_settingValue == nullptr) ? true : false; }
+  std::string GetString() const { return (char*)m_settingValue; }
+  int GetInt() const { return *(int*)m_settingValue; }
+  unsigned int GetUInt() const { return *(unsigned int*)m_settingValue; }
+  bool GetBoolean() const { return *(bool*)m_settingValue; }
+  float GetFloat() const { return *(float*)m_settingValue; }
+
+private:
+  const void *m_settingValue;
+};
+} /* namespace kodi */
+//------------------------------------------------------------------------------
+
+//==============================================================================
+namespace kodi {
+namespace addon {
+/// Add-on settings handle class
+/// @todo need bigger improvement and rework
+class CAddonSetting
+{
+public:
+  enum SETTING_TYPE { NONE=0, CHECK, SPIN };
+
+  CAddonSetting(SETTING_TYPE type, std::string id, std::string label)
+    : Type(type),
+      Id(id),
+      Label(label),
+      Current(0)
   {
-  public:
-    IAddonInstance(ADDON_TYPE type) : m_type(type) { }
-    virtual ~IAddonInstance() { }
+  }
 
-    const ADDON_TYPE m_type;
-  };
-  //
-  //=-----=------=------=------=------=------=------=------=------=------=-----=
-
-
-  //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-  // Add-on settings handle class
-  //
-  class CAddonSetting
+  CAddonSetting(const CAddonSetting &rhs) // copy constructor
   {
-  public:
-    enum SETTING_TYPE { NONE=0, CHECK, SPIN };
+    Id = rhs.Id;
+    Label = rhs.Label;
+    Current = rhs.Current;
+    Type = rhs.Type;
+    for (unsigned int i = 0; i < rhs.Entries.size(); ++i)
+      Entries.push_back(rhs.Entries[i]);
+  }
 
-    CAddonSetting(SETTING_TYPE type, std::string id, std::string label)
-      : Type(type),
-        Id(id),
-        Label(label),
-        Current(0)
-    {
-    }
-
-    CAddonSetting(const CAddonSetting &rhs) // copy constructor
-    {
-      Id = rhs.Id;
-      Label = rhs.Label;
-      Current = rhs.Current;
-      Type = rhs.Type;
-      for (unsigned int i = 0; i < rhs.Entries.size(); ++i)
-        Entries.push_back(rhs.Entries[i]);
-    }
-
-    void AddEntry(std::string label)
-    {
-      if (Label.empty() || Type != SPIN)
-        return;
-      Entries.push_back(Label);
-    }
-
-    // data members
-    SETTING_TYPE Type;
-    std::string Id;
-    std::string Label;
-    int Current;
-    std::vector<std::string> Entries;
-  };
-  //
-  //=-----=------=------=------=------=------=------=------=------=------=-----=
-
-  class CSettingValue
+  void AddEntry(std::string label)
   {
-  public:
-    CSettingValue(const void *settingValue) : m_settingValue(settingValue) {}
-
-    bool empty() const { return (m_settingValue == nullptr) ? true : false; }
-    std::string GetString() const { return (char*)m_settingValue; }
-    int GetInt() const { return *(int*)m_settingValue; }
-    unsigned int GetUInt() const { return *(unsigned int*)m_settingValue; }
-    bool GetBool() const { return *(bool*)m_settingValue; }
-    float GetFloat() const { return *(float*)m_settingValue; }
-
-  private:
-    const void *m_settingValue;
-  };
+    if (Label.empty() || Type != SPIN)
+      return;
+    Entries.push_back(Label);
+  }
 
   //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
   // Function used on Kodi itself to transfer back from add-on given data with
@@ -301,167 +306,175 @@ namespace addon {
       vecSet->push_back(vSet);
     }
   }
-  //
-  //=-----=------=------=------=------=------=------=------=------=------=-----=
 
+  // data members
+  SETTING_TYPE Type;
+  std::string Id;
+  std::string Label;
+  int Current;
+  std::vector<std::string> Entries;
+};
+} /* namespace addon */
+} /* namespace kodi */
+//------------------------------------------------------------------------------
 
-  //-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
-  // Add-on main instance class.
-  //
-  class CAddonBase
+//==============================================================================
+namespace kodi {
+namespace addon {
+/// Add-on main instance class.
+/// @todo need bigger improvement and rework
+class CAddonBase
+{
+public:
+  CAddonBase()
   {
-  public:
-    CAddonBase()
+    CAddonBase::m_interface->toAddon.set_setting = ADDONBASE_SetSetting;
+  }
+
+  virtual ~CAddonBase()
+  {
+  }
+  
+  virtual ADDON_STATUS Create() { return ADDON_STATUS_OK; }
+
+  virtual ADDON_STATUS GetStatus() { return ADDON_STATUS_OK; }
+
+  virtual bool HasSettings() { return false; }
+
+  virtual bool GetSettings(std::vector<CAddonSetting>& settings) { return false; }
+
+  virtual ADDON_STATUS SetSetting(const std::string& settingName, const CSettingValue& settingValue, bool lastSetting) { return ADDON_STATUS_UNKNOWN; }
+
+  virtual ADDON_STATUS CreateInstance(int instanceType, std::string instanceID, KODI_HANDLE instance, KODI_HANDLE& addonInstance)
+  {
+    /* The handling below is intended for the case of the add-on only one
+      * instance and this is integrated in the add-on base class.
+      */
+
+    /* Check about single instance usage */
+    if (CAddonBase::m_interface->firstKodiInstance == instance && // the kodi side instance pointer must be equal to first one
+        CAddonBase::m_interface->globalSingleInstance &&  // the addon side instance pointer must be set
+        CAddonBase::m_interface->globalSingleInstance->m_type == instanceType) // and the requested type must be equal with used add-on class
     {
-      CAddonBase::m_interface->toAddon.set_setting = ADDONBASE_SetSetting;
+      addonInstance = CAddonBase::m_interface->globalSingleInstance;
+      return ADDON_STATUS_OK;
     }
 
-    virtual ~CAddonBase()
+    return ADDON_STATUS_UNKNOWN;
+  }
+
+  /* Global variables of class */
+  static AddonGlobalInterface* m_interface; // Interface function table to hold addresses on add-on and from kodi
+
+/*private:*/ /* Needed public as long the old call functions becomes used! */
+  static inline void ADDONBASE_Destroy()
+  {
+    delete CAddonBase::m_interface->addonBase;
+    CAddonBase::m_interface->addonBase = nullptr;
+  }
+
+  static inline ADDON_STATUS ADDONBASE_GetStatus() { return CAddonBase::m_interface->addonBase->GetStatus(); }
+
+  static inline bool ADDONBASE_HasSettings() { return CAddonBase::m_interface->addonBase->HasSettings(); }
+
+  static inline unsigned int ADDONBASE_GetSettings(ADDON_StructSetting ***sSet)
+  {
+    std::vector<CAddonSetting> settings;
+    if (CAddonBase::m_interface->addonBase->GetSettings(settings))
     {
-    }
-    
-    virtual ADDON_STATUS Create() { return ADDON_STATUS_OK; }
+      *sSet = nullptr;
+      if (settings.empty())
+        return 0;
 
-    virtual ADDON_STATUS GetStatus() { return ADDON_STATUS_OK; }
-
-    virtual bool HasSettings() { return false; }
-
-    virtual bool GetSettings(std::vector<CAddonSetting>& settings) { return false; }
-
-    virtual ADDON_STATUS SetSetting(const std::string& settingName, const CSettingValue& settingValue, bool lastSetting) { return ADDON_STATUS_UNKNOWN; }
-
-    virtual ADDON_STATUS CreateInstance(int instanceType, std::string instanceID, KODI_HANDLE instance, KODI_HANDLE& addonInstance)
-    {
-      /* The handling below is intended for the case of the add-on only one
-       * instance and this is integrated in the add-on base class.
-       */
-
-      /* Check about single instance usage */
-      if (CAddonBase::m_interface->firstKodiInstance == instance && // the kodi side instance pointer must be equal to first one
-          CAddonBase::m_interface->globalSingleInstance &&  // the addon side instance pointer must be set
-          CAddonBase::m_interface->globalSingleInstance->m_type == instanceType) // and the requested type must be equal with used add-on class
+      *sSet = (ADDON_StructSetting**)malloc(settings.size()*sizeof(ADDON_StructSetting*));
+      for (unsigned int i = 0;i < settings.size(); ++i)
       {
-        addonInstance = CAddonBase::m_interface->globalSingleInstance;
-        return ADDON_STATUS_OK;
-      }
+        (*sSet)[i] = nullptr;
+        (*sSet)[i] = (ADDON_StructSetting*)malloc(sizeof(ADDON_StructSetting));
+        (*sSet)[i]->id = nullptr;
+        (*sSet)[i]->label = nullptr;
 
-      return ADDON_STATUS_UNKNOWN;
-    }
-
-    /* Global variables of class */
-    static AddonGlobalInterface* m_interface; // Interface function table to hold addresses on add-on and from kodi
-
-  /*private:*/ /* Needed public as long the old call functions becomes used! */
-    static inline void ADDONBASE_Destroy()
-    {
-      delete CAddonBase::m_interface->addonBase;
-      CAddonBase::m_interface->addonBase = nullptr;
-    }
-
-    static inline ADDON_STATUS ADDONBASE_GetStatus() { return CAddonBase::m_interface->addonBase->GetStatus(); }
-
-    static inline bool ADDONBASE_HasSettings() { return CAddonBase::m_interface->addonBase->HasSettings(); }
-
-    static inline unsigned int ADDONBASE_GetSettings(ADDON_StructSetting ***sSet)
-    {
-      std::vector<CAddonSetting> settings;
-      if (CAddonBase::m_interface->addonBase->GetSettings(settings))
-      {
-        *sSet = nullptr;
-        if (settings.empty())
-          return 0;
-
-        *sSet = (ADDON_StructSetting**)malloc(settings.size()*sizeof(ADDON_StructSetting*));
-        for (unsigned int i = 0;i < settings.size(); ++i)
+        if (!settings[i].Id.empty() && !settings[i].Label.empty())
         {
-          (*sSet)[i] = nullptr;
-          (*sSet)[i] = (ADDON_StructSetting*)malloc(sizeof(ADDON_StructSetting));
-          (*sSet)[i]->id = nullptr;
-          (*sSet)[i]->label = nullptr;
-
-          if (!settings[i].Id.empty() && !settings[i].Label.empty())
+          (*sSet)[i]->id = strdup(settings[i].Id.c_str());
+          (*sSet)[i]->label = strdup(settings[i].Label.c_str());
+          (*sSet)[i]->type = settings[i].Type;
+          (*sSet)[i]->current = settings[i].Current;
+          (*sSet)[i]->entry_elements = 0;
+          (*sSet)[i]->entry = nullptr;
+          if (settings[i].Type == CAddonSetting::SPIN && !settings[i].Entries.empty())
           {
-            (*sSet)[i]->id = strdup(settings[i].Id.c_str());
-            (*sSet)[i]->label = strdup(settings[i].Label.c_str());
-            (*sSet)[i]->type = settings[i].Type;
-            (*sSet)[i]->current = settings[i].Current;
-            (*sSet)[i]->entry_elements = 0;
-            (*sSet)[i]->entry = nullptr;
-            if (settings[i].Type == CAddonSetting::SPIN && !settings[i].Entries.empty())
+            (*sSet)[i]->entry = (char**)malloc(settings[i].Entries.size()*sizeof(char**));
+            for (unsigned int j = 0; j < settings[i].Entries.size(); ++j)
             {
-              (*sSet)[i]->entry = (char**)malloc(settings[i].Entries.size()*sizeof(char**));
-              for (unsigned int j = 0; j < settings[i].Entries.size(); ++j)
+              if (!settings[i].Entries[j].empty())
               {
-                if (!settings[i].Entries[j].empty())
-                {
-                  (*sSet)[i]->entry[j] = strdup(settings[i].Entries[j].c_str());
-                  (*sSet)[i]->entry_elements++;
-                }
+                (*sSet)[i]->entry[j] = strdup(settings[i].Entries[j].c_str());
+                (*sSet)[i]->entry_elements++;
               }
             }
           }
         }
-
-        return settings.size();
       }
-      return 0;
+
+      return settings.size();
     }
+    return 0;
+  }
 
-    static inline ADDON_STATUS ADDONBASE_SetSetting(const char *settingName, const void *settingValue, bool lastSetting)
+  static inline ADDON_STATUS ADDONBASE_SetSetting(const char *settingName, const void *settingValue, bool lastSetting)
+  {
+    return CAddonBase::m_interface->addonBase->SetSetting(settingName, CSettingValue(settingValue), lastSetting);
+  }
+
+  static inline void ADDONBASE_FreeSettings(unsigned int elements, ADDON_StructSetting*** set)
+  {
+    if (elements == 0)
+      return;
+
+    for (unsigned int i = 0; i < elements; ++i)
     {
-      return CAddonBase::m_interface->addonBase->SetSetting(settingName, CSettingValue(settingValue), lastSetting);
-    }
-
-    static inline void ADDONBASE_FreeSettings(unsigned int elements, ADDON_StructSetting*** set)
-    {
-      if (elements == 0)
-        return;
-
-      for (unsigned int i = 0; i < elements; ++i)
+      if ((*set)[i]->type == CAddonSetting::SPIN)
       {
-        if ((*set)[i]->type == CAddonSetting::SPIN)
+        for (unsigned int j = 0; j < (*set)[i]->entry_elements; ++j)
         {
-          for (unsigned int j = 0; j < (*set)[i]->entry_elements; ++j)
-          {
-            free((*set)[i]->entry[j]);
-          }
-          free((*set)[i]->entry);
+          free((*set)[i]->entry[j]);
         }
-        free((*set)[i]->id);
-        free((*set)[i]->label);
-        free((*set)[i]);
+        free((*set)[i]->entry);
       }
-      free(*set);
+      free((*set)[i]->id);
+      free((*set)[i]->label);
+      free((*set)[i]);
     }
+    free(*set);
+  }
 
-    static inline ADDON_STATUS ADDONBASE_CreateInstance(int instanceType, const char* instanceID, KODI_HANDLE instance, KODI_HANDLE* addonInstance)
+  static inline ADDON_STATUS ADDONBASE_CreateInstance(int instanceType, const char* instanceID, KODI_HANDLE instance, KODI_HANDLE* addonInstance)
+  {
+    ADDON_STATUS status = CAddonBase::m_interface->addonBase->CreateInstance(instanceType, instanceID, instance, *addonInstance);
+    if (*addonInstance == nullptr)
+      throw std::logic_error("kodi::addon::CAddonBase CreateInstance returns a empty instance pointer!");
+
+    if (static_cast<::kodi::addon::IAddonInstance*>(*addonInstance)->m_type != instanceType)
+      throw std::logic_error("kodi::addon::CAddonBase CreateInstance with difference on given and returned instance type!");
+
+    return status;
+  }
+
+  static inline void ADDONBASE_DestroyInstance(int instanceType, KODI_HANDLE instance)
+  {
+    if (CAddonBase::m_interface->globalSingleInstance == nullptr && instance != CAddonBase::m_interface->addonBase)
     {
-      ADDON_STATUS status = CAddonBase::m_interface->addonBase->CreateInstance(instanceType, instanceID, instance, *addonInstance);
-      if (*addonInstance == nullptr)
-        throw std::logic_error("kodi::addon::CAddonBase CreateInstance returns a empty instance pointer!");
-
-      if (static_cast<::kodi::addon::IAddonInstance*>(*addonInstance)->m_type != instanceType)
-        throw std::logic_error("kodi::addon::CAddonBase CreateInstance with difference on given and returned instance type!");
-
-      return status;
+      if (static_cast<::kodi::addon::IAddonInstance*>(instance)->m_type == instanceType)
+        delete static_cast<::kodi::addon::IAddonInstance*>(instance);
+      else
+        throw std::logic_error("kodi::addon::CAddonBase DestroyInstance called with difference on given and present instance type!");
     }
-
-    static inline void ADDONBASE_DestroyInstance(int instanceType, KODI_HANDLE instance)
-    {
-      if (CAddonBase::m_interface->globalSingleInstance == nullptr && instance != CAddonBase::m_interface->addonBase)
-      {
-        if (static_cast<::kodi::addon::IAddonInstance*>(instance)->m_type == instanceType)
-          delete static_cast<::kodi::addon::IAddonInstance*>(instance);
-        else
-          throw std::logic_error("kodi::addon::CAddonBase DestroyInstance called with difference on given and present instance type!");
-      }
-    }
-  };
-  //
-  //=-----=------=------=------=------=------=------=------=------=------=-----=
-
+  }
+};
 } /* namespace addon */
 } /* namespace kodi */
+//------------------------------------------------------------------------------
 
 //==============================================================================
 namespace kodi {

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/AddonBase.h
@@ -143,6 +143,7 @@ typedef ADDON_HANDLE_STRUCT *ADDON_HANDLE;
  * Set complete from Kodi!
  */
 struct AddonToKodiFuncTable_kodi;
+struct AddonToKodiFuncTable_kodi_gui;
 typedef struct AddonToKodiFuncTable_Addon
 {
   // Pointer inside Kodi, used on callback functions to give related handle
@@ -156,6 +157,7 @@ typedef struct AddonToKodiFuncTable_Addon
   void (*free_string)(void* kodiBase, char* str);
 
   AddonToKodiFuncTable_kodi* kodi;
+  AddonToKodiFuncTable_kodi_gui* kodi_gui;
 } AddonToKodiFuncTable_Addon;
 
 /*

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/General.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/General.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *      Copyright (C) 2005-2016 Team Kodi
+ *      Copyright (C) 2005-2017 Team Kodi
  *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/General.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/General.h
@@ -41,6 +41,7 @@ typedef struct AddonToKodiFuncTable_kodi
   bool (*get_setting)(void* kodiBase, const char* settingName, void *settingValue);
   bool (*set_setting)(void* kodiBase, const char* settingName, const char* settingValue);
   void (*open_settings_dialog)(void* kodiBase);
+  char* (*get_localized_string)(void* kodiInstance, long dwCode);
 } AddonToKodiFuncTable_kodi;
 
 } /* extern "C" */
@@ -166,6 +167,22 @@ namespace kodi
   inline void OpenSettings()
   {
     ::kodi::addon::CAddonBase::m_interface->toKodi.kodi->open_settings_dialog(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase);
+  }
+  //----------------------------------------------------------------------------
+
+  //============================================================================
+  ///
+  inline std::string GetLocalizedString(uint32_t labelId, const std::string& defaultStr = "")
+  {
+    std::string retString = defaultStr;
+    char* strMsg = ::kodi::addon::CAddonBase::m_interface->toKodi.kodi->get_localized_string(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, labelId);
+    if (strMsg != nullptr)
+    {
+      if (std::strlen(strMsg))
+        retString = strMsg;
+      ::kodi::addon::CAddonBase::m_interface->toKodi.free_string(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase,strMsg);
+    }
+    return retString;
   }
   //----------------------------------------------------------------------------
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogOK.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/DialogOK.h
@@ -1,0 +1,101 @@
+#pragma once
+/*
+ *      Copyright (C) 2015-2017 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../AddonBase.h"
+#include "definitions.h"
+
+namespace kodi
+{
+namespace gui
+{
+
+  //============================================================================
+  ///
+  /// \defgroup cpp_kodi_gui_DialogOK Dialog OK
+  /// \ingroup cpp_kodi_gui
+  /// @{
+  /// @brief \cpp_namespace{ kodi::gui::DialogOK }
+  /// **OK dialog**
+  ///
+  /// The functions listed below permit the call of a dialogue of information, a
+  /// confirmation of the user by press from OK required.
+  ///
+  /// These are pure static functions them no other initialization need.
+  ///
+  /// It has the header \ref DialogOK.h "#include <kodi/gui/DialogOK.h>"
+  /// be included to enjoy it.
+  ///
+  namespace DialogOK
+  {
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogOK
+    /// @brief Use dialog to inform user with text and confirmation with OK with continued string.
+    ///
+    /// @param[in] heading Dialog heading.
+    /// @param[in] text Multi-line text.
+    ///
+    ///
+    ///-------------------------------------------------------------------------
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.cpp}
+    /// #include <kodi/gui/DialogOK.h>
+    /// ...
+    /// kodi::gui::DialogOK::ShowAndGetInput("Test dialog", "Hello World!\nI'm a call from add-on\n :) :D");
+    /// ~~~~~~~~~~~~~
+    ///
+    inline void ShowAndGetInput(const std::string& heading, const std::string& text)
+    {
+      ::kodi::addon::CAddonBase::m_interface->toKodi.kodi_gui->dialogOK.show_and_get_input_single_text(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, heading.c_str(), text.c_str());
+    }
+    //--------------------------------------------------------------------------
+
+    //==========================================================================
+    ///
+    /// \ingroup cpp_kodi_gui_DialogOK
+    /// @brief Use dialog to inform user with text and confirmation with OK with strings separated to the lines.
+    ///
+    /// @param[in] heading Dialog heading.
+    /// @param[in] line0 Line #1 text.
+    /// @param[in] line1 Line #2 text.
+    /// @param[in] line2 Line #3 text.
+    ///
+    ///
+    ///-------------------------------------------------------------------------
+    ///
+    /// **Example:**
+    /// ~~~~~~~~~~~~~{.cpp}
+    /// #include <kodi/gui/DialogOK.h>
+    /// ...
+    /// kodi::gui::DialogOK::ShowAndGetInput("Test dialog", "Hello World!", "I'm a call from add-on", " :) :D");
+    /// ~~~~~~~~~~~~~
+    ///
+    inline void ShowAndGetInput(const std::string& heading, const std::string& line0, const std::string& line1, const std::string& line2)
+    {
+      ::kodi::addon::CAddonBase::m_interface->toKodi.kodi_gui->dialogOK.show_and_get_input_line_text(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase, heading.c_str(), line0.c_str(), line1.c_str(), line2.c_str());
+    }
+    //--------------------------------------------------------------------------
+  }
+  /// @}
+
+} /* namespace gui */
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/General.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/General.h
@@ -1,0 +1,149 @@
+#pragma once
+/*
+ *      Copyright (C) 2015-2017 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../AddonBase.h"
+#include "definitions.h"
+
+namespace kodi
+{
+namespace gui
+{
+
+  //============================================================================
+  ///
+  // \defgroup cpp_kodi_gui ::general
+  /// \addtogroup cpp_kodi_gui
+  /// @{
+  /// @brief **Allow use of binary classes and function to use on add-on's**
+  ///
+  /// Permits the use of the required functions of the add-on to Kodi. This class
+  /// also contains some functions to the control.
+  ///
+  /// These are pure functions them no other initialization need.
+  ///
+  /// It has the header \ref kodi/gui/General.h "#include <kodi/gui/General.h>" be included
+  /// to enjoy it.
+  ///
+
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui
+  /// @brief Performs a graphical lock of rendering engine
+  ///
+  inline void Lock()
+  {
+    ::kodi::addon::CAddonBase::m_interface->toKodi.kodi_gui->general.lock();
+  }
+
+  //--------------------------------------------------------------------------
+
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui
+  /// @brief Performs a graphical unlock of previous locked rendering engine
+  ///
+  inline void Unlock()
+  {
+    ::kodi::addon::CAddonBase::m_interface->toKodi.kodi_gui->general.unlock();
+  }
+  //--------------------------------------------------------------------------
+
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui
+  /// @brief Return the the current screen height with pixel
+  ///
+  inline int GetScreenHeight()
+  {
+    return ::kodi::addon::CAddonBase::m_interface->toKodi.kodi_gui->general.get_screen_height(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase);
+  }
+  //--------------------------------------------------------------------------
+
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui
+  /// @brief Return the the current screen width with pixel
+  ///
+  inline int GetScreenWidth()
+  {
+    return ::kodi::addon::CAddonBase::m_interface->toKodi.kodi_gui->general.get_screen_width(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase);
+  }
+  //--------------------------------------------------------------------------
+
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui
+  /// @brief Return the the current screen rendering resolution
+  ///
+  inline int GetVideoResolution()
+  {
+    return ::kodi::addon::CAddonBase::m_interface->toKodi.kodi_gui->general.get_video_resolution(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase);
+  }
+  //--------------------------------------------------------------------------
+
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui
+  /// @brief Returns the id for the current 'active' dialog as an integer.
+  ///
+  /// @return                        The currently active dialog Id
+  ///
+  ///
+  ///-------------------------------------------------------------------------
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.cpp}
+  /// ..
+  /// int wid = kodi::gui::general::GetCurrentWindowDialogId()
+  /// ..
+  /// ~~~~~~~~~~~~~
+  ///
+  inline int GetCurrentWindowDialogId()
+  {
+    return ::kodi::addon::CAddonBase::m_interface->toKodi.kodi_gui->general.get_current_window_dialog_id(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase);
+  }
+  //--------------------------------------------------------------------------
+
+  //==========================================================================
+  ///
+  /// \ingroup cpp_kodi_gui
+  /// @brief Returns the id for the current 'active' window as an integer.
+  ///
+  /// @return                        The currently active window Id
+  ///
+  ///
+  ///-------------------------------------------------------------------------
+  ///
+  /// **Example:**
+  /// ~~~~~~~~~~~~~{.cpp}
+  /// ..
+  /// int wid = kodi::gui::general::GetCurrentWindowId()
+  /// ..
+  /// ~~~~~~~~~~~~~
+  ///
+  inline int GetCurrentWindowId()
+  {
+    return ::kodi::addon::CAddonBase::m_interface->toKodi.kodi_gui->general.get_current_window_id(::kodi::addon::CAddonBase::m_interface->toKodi.kodiBase);
+  }
+  //--------------------------------------------------------------------------
+
+} /* namespace gui */
+} /* namespace kodi */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/definitions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/gui/definitions.h
@@ -1,0 +1,54 @@
+#pragma once
+/*
+ *      Copyright (C) 2016 Team KODI
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with KODI; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+#include <time.h>
+
+/*
+ * Internal Structures to have "C"-Style data transfer
+ */
+extern "C"
+{
+
+typedef struct AddonToKodiFuncTable_kodi_gui_dialogOK
+{
+  void (*show_and_get_input_single_text)(void* kodiBase, const char *heading, const char *text);
+  void (*show_and_get_input_line_text)(void* kodiBase, const char *heading, const char *line0, const char *line1, const char *line2);
+} AddonToKodiFuncTable_kodi_gui_dialogOK;
+
+typedef struct AddonToKodiFuncTable_kodi_gui_general
+{
+  void (*lock)();
+  void (*unlock)();
+  int (*get_screen_height)(void* kodiBase);
+  int (*get_screen_width)(void* kodiBase);
+  int (*get_video_resolution)(void* kodiBase);
+  int (*get_current_window_dialog_id)(void* kodiBase);
+  int (*get_current_window_id)(void* kodiBase);
+} AddonToKodiFuncTable_kodi_gui_general;
+
+typedef struct AddonToKodiFuncTable_kodi_gui
+{
+  AddonToKodiFuncTable_kodi_gui_general general;
+  AddonToKodiFuncTable_kodi_gui_dialogOK dialogOK;
+} AddonToKodiFuncTable_kodi_gui;
+
+} /* extern "C" */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/screensaver/Screensaver.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/screensaver/Screensaver.h
@@ -1,6 +1,6 @@
 #pragma once
 /*
- *      Copyright (C) 2005-2016 Team Kodi
+ *      Copyright (C) 2005-2017 Team Kodi
  *      http://kodi.tv
  *
  *  This Program is free software; you can redistribute it and/or modify
@@ -21,10 +21,10 @@
 
 #include "../AddonBase.h"
 
+namespace kodi { namespace addon { class CInstanceScreensaver; }}
+
 extern "C"
 {
-
-namespace kodi { namespace addon { class CInstanceScreensaver; }}
 
 typedef struct AddonProps_Screensaver
 {
@@ -57,6 +57,8 @@ typedef struct AddonInstance_Screensaver
   AddonToKodiFuncTable_Screensaver toKodi;
   KodiToAddonFuncTable_Screensaver toAddon;
 } AddonInstance_Screensaver;
+
+} /* extern "C" */
 
 namespace kodi
 {
@@ -133,4 +135,3 @@ namespace addon
 
 } /* namespace addon */
 } /* namespace kodi */
-} /* extern "C" */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/visualization/Visualization.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/visualization/Visualization.h
@@ -21,6 +21,8 @@
 
 #include "../AddonBase.h"
 
+namespace kodi { namespace addon { class CInstanceVisualization; }}
+
 extern "C"
 {
 
@@ -43,8 +45,6 @@ struct VIS_INFO
   bool bWantsFreq;
   int iSyncDelay;
 };
-
-namespace kodi { namespace addon { class CInstanceVisualization; }}
 
 typedef struct AddonProps_Visualization
 {
@@ -87,6 +87,8 @@ typedef struct AddonInstance_Visualization
   KodiToAddonFuncTable_Visualization toAddon;
 } AddonInstance_Visualization;
 
+} /* extern "C" */
+
 namespace kodi
 {
 namespace addon
@@ -113,13 +115,13 @@ namespace addon
     const char *reserved1;
     const char *reserved2;
 
-    int        trackNumber;
-    int        discNumber;
-    int        duration;
-    int        year;
-    char       rating;
-    int        reserved3;
-    int        reserved4;
+    int trackNumber;
+    int discNumber;
+    int duration;
+    int year;
+    char rating;
+    int reserved3;
+    int reserved4;
   };
 
   class CInstanceVisualization : public IAddonInstance
@@ -285,4 +287,3 @@ namespace addon
 
 } /* namespace addon */
 } /* namespace kodi */
-} /* extern "C" */

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/visualization/Visualization.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/visualization/Visualization.h
@@ -166,7 +166,7 @@ namespace addon
     virtual bool LockPreset(bool lockUnlock) { return false; }
     virtual bool RatePreset(bool plusMinus) { return false; }
     virtual bool UpdateAlbumart(std::string albumart) { return false; }
-    virtual bool UpdateTrack(const VisTrack &track) { return false; }
+    virtual bool UpdateTrack(const kodi::addon::VisTrack &track) { return false; }
 
     inline void* Device() { return m_instanceData->props.device; }
     inline int X() { return m_instanceData->props.x; }


### PR DESCRIPTION
This does the next cleanup of new add-on headers and bring in the initial new gui interface (currently only with OK Dialog and standard function).

Currently still using screensavers and visualizations to test new interface ways, on add-on side it works very nice.

Also makes itself really proven to use a namespace with the developer software. There comes with them a very easy auto update and select of functions and parts :D