### PR TITLE
[MMAL] Fixes for stalled video

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
@@ -730,6 +730,9 @@ int CMMALVideo::GetPicture(DVDVideoPicture* pDvdVideoPicture)
   bool drain = (m_codecControlFlags & DVD_CODEC_CTRL_DRAIN) ? true : false;
   bool send_eos = drain && !m_got_eos && m_packet_num_eos != m_packet_num;
 
+  if (m_pool)
+    m_pool->Prime();
+
   // we don't get an EOS response if no packets have been sent
   if (m_packet_num == 0 && send_eos)
     m_got_eos = true;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
@@ -360,10 +360,10 @@ bool CMMALVideo::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
 {
   CSingleLock lock(m_sharedSection);
   if (g_advancedSettings.CanLogComponent(LOGVIDEO))
-    CLog::Log(LOGDEBUG, "%s::%s usemmal:%d software:%d %dx%d renderer:%p", CLASSNAME, __func__, CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_USEMMAL), hints.software, hints.width, hints.height, options.m_opaque_pointer);
+    CLog::Log(LOGDEBUG, "%s::%s usemmal:%d software:%d %dx%d renderer:%p", CLASSNAME, __func__, CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_USEMMAL), hints.codecOptions & CODEC_FORCE_SOFTWARE ? 1:0, hints.width, hints.height, options.m_opaque_pointer);
 
   // we always qualify even if DVDFactoryCodec does this too.
-  if (!CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_USEMMAL) || hints.software)
+  if (!CServiceBroker::GetSettings().GetBool(CSettings::SETTING_VIDEOPLAYER_USEMMAL) || (hints.codecOptions & CODEC_FORCE_SOFTWARE))
     return false;
 
   std::list<EINTERLACEMETHOD> deintMethods;

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
@@ -502,7 +502,7 @@ bool CMMALVideo::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options)
   if (status != MMAL_SUCCESS)
     CLog::Log(LOGERROR, "%s::%s Failed to disable error concealment on %s (status=%x %s)", CLASSNAME, __func__, m_dec_input->name, status, mmal_status_to_string(status));
 
-  status = mmal_port_parameter_set_uint32(m_dec_input, MMAL_PARAMETER_EXTRA_BUFFERS, GetAllowedReferences()+1);
+  status = mmal_port_parameter_set_uint32(m_dec_input, MMAL_PARAMETER_EXTRA_BUFFERS, GetAllowedReferences());
   if (status != MMAL_SUCCESS)
     CLog::Log(LOGERROR, "%s::%s Failed to enable extra buffers on %s (status=%x %s)", CLASSNAME, __func__, m_dec_input->name, status, mmal_status_to_string(status));
 


### PR DESCRIPTION
Found the real reason for needing an extra decoded picture.
We now call GetPicture more than AddData, so we are not calling Prime
(which releases unreferenced pictures back to MMAL) enough.
Adding the extra Prime call means the extra picture is not required.