### PR TITLE
change type od cap mask to avoid errors when building masks

### DIFF
--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_inputstream_types.h
@@ -65,7 +65,7 @@ extern "C" {
     };
 
     /// set of supported capabilities
-    MASKTYPE m_mask;
+    uint32_t m_mask;
   } INPUTSTREAM_CAPABILITIES;
 
   /*!


### PR DESCRIPTION
see title.

enum values forbid making bit combinations as they are thougt to be a unique value.
This PR makes mask building lot easier.