### PR TITLE
VideoPlayer: cleanup videoCodec interface

### DIFF
--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodec.h
@@ -155,20 +155,22 @@ class CDVDStreamInfo;
 class CDVDCodecOption;
 class CDVDCodecOptions;
 
-// VC_ messages, messages can be combined
-#define VC_ERROR                    0x00000001  //< an error occured, no other messages will be returned
-#define VC_BUFFER                   0x00000002  //< the decoder needs more data
-#define VC_PICTURE                  0x00000004  //< the decoder got a picture, call Decode(NULL, 0) again to parse the rest of the data
-#define VC_USERDATA                 0x00000008  //< the decoder found some userdata,  call Decode(NULL, 0) again to parse the rest of the data
-#define VC_FLUSHED                  0x00000010  //< the decoder lost it's state, we need to restart decoding again
-#define VC_DROPPED                  0x00000020  //< needed to identify if a picture was dropped
-#define VC_NOBUFFER                 0x00000040  //< last FFmpeg GetBuffer failed
-#define VC_REOPEN                   0x00000080  //< decoder request to re-open
-#define VC_EOF                      0x00000100  //< EOF
-
 class CDVDVideoCodec
 {
 public:
+
+  enum VCReturn
+  {
+    VC_NONE = 0,
+    VC_ERROR,           //< an error occured, no other messages will be returned
+    VC_BUFFER,          //< the decoder needs more data
+    VC_PICTURE,         //< the decoder got a picture, call Decode(NULL, 0) again to parse the rest of the data
+    VC_FLUSHED,         //< the decoder lost it's state, we need to restart decoding again
+    VC_NOBUFFER,        //< last FFmpeg GetBuffer failed
+    VC_REOPEN,          //< decoder request to re-open
+    VC_EOF              //< EOF
+  };
+
   CDVDVideoCodec(CProcessInfo &processInfo) : m_processInfo(processInfo) {}
   virtual ~CDVDVideoCodec() {}
 
@@ -191,9 +193,10 @@ public:
   }
 
   /**
-   * returns one or a combination of VC_ messages
+   * add data, decoder has to consume the entire packet
+   * returns true if the packet was consumed or if resubmitting it is useless
    */
-  virtual int AddData(const DemuxPacket &packet) = 0;
+  virtual bool AddData(const DemuxPacket &packet) = 0;
 
   /**
    * Reset the decoder.
@@ -202,10 +205,11 @@ public:
   virtual void Reset() = 0;
 
   /**
-   * returns one or a combination of VC_ messages
-   * the data is valid until the next GetPicture call
+   * GetPicture controls decoding. Player calls it on every cycle
+   * it can signal a picture, request a buffer, or return none, if nothing applies
+   * the data is valid until the next GetPicture return VC_PICTURE
    */
-  virtual int GetPicture(DVDVideoPicture* pDvdVideoPicture) = 0;
+  virtual VCReturn GetPicture(DVDVideoPicture* pDvdVideoPicture) = 0;
 
   /**
    * returns true if successfull
@@ -314,9 +318,9 @@ public:
   IHardwareDecoder() = default;
   virtual ~IHardwareDecoder() = default;
   virtual bool Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum AVPixelFormat, unsigned int surfaces) = 0;
-  virtual int  Decode(AVCodecContext* avctx, AVFrame* frame) = 0;
+  virtual CDVDVideoCodec::VCReturn Decode(AVCodecContext* avctx, AVFrame* frame) = 0;
   virtual bool GetPicture(AVCodecContext* avctx, DVDVideoPicture* picture) = 0;
-  virtual int  Check(AVCodecContext* avctx) = 0;
+  virtual CDVDVideoCodec::VCReturn Check(AVCodecContext* avctx) = 0;
   virtual void Reset() {}
   virtual unsigned GetAllowedReferences() { return 0; }
   virtual bool CanSkipDeint() {return false; }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -586,7 +586,7 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecFFmpeg::GetPicture(DVDVideoPicture* pDvdV
         if (m_pHardware->GetPicture(m_pCodecContext, pDvdVideoPicture))
           return VC_PICTURE;
         else
-          return VC_BUFFER;
+          return VC_ERROR;
       }
       else
       {
@@ -684,7 +684,7 @@ CDVDVideoCodec::VCReturn CDVDVideoCodecFFmpeg::GetPicture(DVDVideoPicture* pDvdV
         return VC_ERROR;
     }
 
-    return VC_NONE;
+    return ret;
   }
   // process filters for sw decoding
   else

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
@@ -459,23 +459,18 @@ static int64_t pts_dtoi(double pts)
   return u.pts_i;
 }
 
-int CDVDVideoCodecFFmpeg::AddData(const DemuxPacket &packet)
+bool CDVDVideoCodecFFmpeg::AddData(const DemuxPacket &packet)
 {
   if (!m_pCodecContext)
-    return VC_ERROR;
+    return true;
 
   if (!packet.pData)
-    return VC_ERROR;
+    return true;
 
   if (m_eof)
   {
     Reset();
   }
-
-  m_iLastKeyframe++;
-  // put a limit on convergence count to avoid huge mem usage on streams without keyframes
-  if (m_iLastKeyframe > 300)
-    m_iLastKeyframe = 300;
 
   m_dts = packet.dts;
   m_pCodecContext->reordered_opaque = pts_dtoi(packet.pts);
@@ -492,7 +487,7 @@ int CDVDVideoCodecFFmpeg::AddData(const DemuxPacket &packet)
   // try again
   if (ret == AVERROR(EAGAIN))
   {
-    return 0;
+    return false;
   }
   // error
   else if (ret)
@@ -501,21 +496,22 @@ int CDVDVideoCodecFFmpeg::AddData(const DemuxPacket &packet)
     if (m_pHardware)
     {
       int result = m_pHardware->Check(m_pCodecContext);
-      while (result == VC_NOBUFFER)
+      if (result == VC_NOBUFFER)
       {
-        ret = avcodec_send_packet(m_pCodecContext, &avpkt);
-        if (ret == 0)
-          break;
-        result = m_pHardware->Check(m_pCodecContext);
+        return false;
       }
     }
-    return VC_ERROR;
   }
 
-  return 0;
+  m_iLastKeyframe++;
+  // put a limit on convergence count to avoid huge mem usage on streams without keyframes
+  if (m_iLastKeyframe > 300)
+    m_iLastKeyframe = 300;
+
+  return true;
 }
 
-int CDVDVideoCodecFFmpeg::GetPicture(DVDVideoPicture* pDvdVideoPicture)
+CDVDVideoCodec::VCReturn CDVDVideoCodecFFmpeg::GetPicture(DVDVideoPicture* pDvdVideoPicture)
 {
   if (m_eof)
   {
@@ -528,29 +524,29 @@ int CDVDVideoCodecFFmpeg::GetPicture(DVDVideoPicture* pDvdVideoPicture)
     int flags = m_codecControlFlags;
     flags &= ~DVD_CODEC_CTRL_DRAIN;
     m_pHardware->SetCodecControl(flags);
-    int ret = m_pHardware->Decode(m_pCodecContext, nullptr);
-    if (ret & VC_PICTURE)
+    CDVDVideoCodec::VCReturn ret = m_pHardware->Decode(m_pCodecContext, nullptr);
+    if (ret == VC_PICTURE)
     {
       if (m_pHardware->GetPicture(m_pCodecContext, pDvdVideoPicture))
         return VC_PICTURE;
       else
         return VC_ERROR;
     }
-    else if (ret & VC_BUFFER)
+    else if (ret == VC_BUFFER)
       ;
     else
       return ret;
   }
   else if (m_pFilterGraph && !m_filterEof)
   {
-    int ret = FilterProcess(nullptr);
-    if (ret & VC_PICTURE)
+    CDVDVideoCodec::VCReturn ret = FilterProcess(nullptr);
+    if (ret == VC_PICTURE)
     {
       if (!SetPictureParams(pDvdVideoPicture))
         return VC_ERROR;
       return VC_PICTURE;
     }
-    else if (ret & VC_BUFFER)
+    else if (ret == VC_BUFFER)
       ;
     else
       return ret;
@@ -585,8 +581,13 @@ int CDVDVideoCodecFFmpeg::GetPicture(DVDVideoPicture* pDvdVideoPicture)
       flags |= DVD_CODEC_CTRL_DRAIN;
       m_pHardware->SetCodecControl(flags);
       int ret = m_pHardware->Decode(m_pCodecContext, nullptr);
-      if (ret & VC_PICTURE)
-        return m_pHardware->GetPicture(m_pCodecContext, pDvdVideoPicture);
+      if (ret == VC_PICTURE)
+      {
+        if (m_pHardware->GetPicture(m_pCodecContext, pDvdVideoPicture))
+          return VC_PICTURE;
+        else
+          return VC_BUFFER;
+      }
       else
       {
         m_eof = true;
@@ -597,7 +598,7 @@ int CDVDVideoCodecFFmpeg::GetPicture(DVDVideoPicture* pDvdVideoPicture)
     else if (m_pFilterGraph && !m_filterEof)
     {
       int ret = FilterProcess(nullptr);
-      if (ret & VC_PICTURE)
+      if (ret == VC_PICTURE)
       {
         if (!SetPictureParams(pDvdVideoPicture))
           return VC_ERROR;
@@ -669,13 +670,13 @@ int CDVDVideoCodecFFmpeg::GetPicture(DVDVideoPicture* pDvdVideoPicture)
   {
     av_frame_unref(m_pFrame);
     av_frame_move_ref(m_pFrame, m_pDecodedFrame);
-    int ret = m_pHardware->Decode(m_pCodecContext, m_pFrame);
-    if (ret & VC_FLUSHED)
+    CDVDVideoCodec::VCReturn ret = m_pHardware->Decode(m_pCodecContext, m_pFrame);
+    if (ret == VC_FLUSHED)
     {
       Reset();
       return ret;
     }
-    else if (ret & VC_PICTURE)
+    else if (ret == VC_PICTURE)
     {
       if (m_pHardware->GetPicture(m_pCodecContext, pDvdVideoPicture))
         return VC_PICTURE;
@@ -683,8 +684,7 @@ int CDVDVideoCodecFFmpeg::GetPicture(DVDVideoPicture* pDvdVideoPicture)
         return VC_ERROR;
     }
 
-    ret &= ~VC_PICTURE;
-    return ret;
+    return VC_NONE;
   }
   // process filters for sw decoding
   else
@@ -721,9 +721,9 @@ int CDVDVideoCodecFFmpeg::GetPicture(DVDVideoPicture* pDvdVideoPicture)
 
     if (m_pFilterGraph && !m_filterEof)
     {
-      int ret = FilterProcess(m_pDecodedFrame);
-      if (!(ret & VC_PICTURE))
-        return ret;
+      CDVDVideoCodec::VCReturn ret = FilterProcess(m_pDecodedFrame);
+      if (ret != VC_PICTURE)
+        return VC_NONE;
     }
     else
     {
@@ -737,7 +737,7 @@ int CDVDVideoCodecFFmpeg::GetPicture(DVDVideoPicture* pDvdVideoPicture)
       return VC_PICTURE;
   }
 
-  return 0;
+  return VC_NONE;
 }
 
 bool CDVDVideoCodecFFmpeg::SetPictureParams(DVDVideoPicture* pDvdVideoPicture)
@@ -1037,7 +1037,7 @@ void CDVDVideoCodecFFmpeg::FilterClose()
   }
 }
 
-int CDVDVideoCodecFFmpeg::FilterProcess(AVFrame* frame)
+CDVDVideoCodec::VCReturn CDVDVideoCodecFFmpeg::FilterProcess(AVFrame* frame)
 {
   int result;
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h
@@ -43,10 +43,10 @@ public:
   CDVDVideoCodecFFmpeg(CProcessInfo &processInfo);
   virtual ~CDVDVideoCodecFFmpeg();
   virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options) override;
-  virtual int AddData(const DemuxPacket &packet) override;
+  virtual bool AddData(const DemuxPacket &packet) override;
   virtual void Reset() override;
   virtual void Reopen() override;
-  virtual int GetPicture(DVDVideoPicture* pDvdVideoPicture) override;
+  virtual CDVDVideoCodec::VCReturn GetPicture(DVDVideoPicture* pDvdVideoPicture) override;
   virtual const char* GetName() override { return m_name.c_str(); }; // m_name is never changed after open
   virtual unsigned GetConvergeCount() override;
   virtual unsigned GetAllowedReferences() override;
@@ -62,7 +62,7 @@ protected:
 
   int  FilterOpen(const std::string& filters, bool scale);
   void FilterClose();
-  int  FilterProcess(AVFrame* frame);
+  CDVDVideoCodec::VCReturn FilterProcess(AVFrame* frame);
   void SetFilters();
   void UpdateName();
   bool SetPictureParams(DVDVideoPicture* pDvdVideoPicture);

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/DXVA.h
@@ -120,9 +120,9 @@ public:
 
   // IHardwareDecoder overrides
   bool Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum AVPixelFormat, unsigned int surfaces) override;
-  int Decode(AVCodecContext* avctx, AVFrame* frame) override;
+  CDVDVideoCodec::VCReturn Decode(AVCodecContext* avctx, AVFrame* frame) override;
   bool GetPicture(AVCodecContext* avctx, DVDVideoPicture* picture) override;
-  int Check(AVCodecContext* avctx) override;
+  CDVDVideoCodec::VCReturn Check(AVCodecContext* avctx) override;
   const std::string Name() override { return "d3d11va"; }
   unsigned GetAllowedReferences() override;
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.cpp
@@ -595,7 +595,7 @@ void CMMALVideo::Dispose()
   Reset();
 }
 
-int CMMALVideo::AddData(const DemuxPacket &packet)
+bool CMMALVideo::AddData(const DemuxPacket &packet)
 {
   CSingleLock lock(m_sharedSection);
   //if (g_advancedSettings.CanLogComponent(LOGVIDEO))
@@ -620,7 +620,7 @@ int CMMALVideo::AddData(const DemuxPacket &packet)
     if (!buffer)
     {
       CLog::Log(LOGERROR, "%s::%s - mmal_queue_get failed", CLASSNAME, __func__);
-      return VC_ERROR;
+      return true;
     }
     lock.Enter();
 
@@ -652,7 +652,7 @@ int CMMALVideo::AddData(const DemuxPacket &packet)
     if (status != MMAL_SUCCESS)
     {
       CLog::Log(LOGERROR, "%s::%s Failed send buffer to decoder input port (status=%x %s)", CLASSNAME, __func__, status, mmal_status_to_string(status));
-      return VC_ERROR;
+      return true;
     }
   }
   if (pts != DVD_NOPTS_VALUE)
@@ -663,7 +663,7 @@ int CMMALVideo::AddData(const DemuxPacket &packet)
   if (m_demuxerPts != DVD_NOPTS_VALUE && m_decoderPts == DVD_NOPTS_VALUE)
     m_decoderPts = m_demuxerPts;
 
-  return 0;
+  return true;
 }
 
 void CMMALVideo::Reset(void)
@@ -727,7 +727,7 @@ void CMMALVideo::SetSpeed(int iSpeed)
   m_speed = iSpeed;
 }
 
-int CMMALVideo::GetPicture(DVDVideoPicture* pDvdVideoPicture)
+CDVDVideoCodec::VCReturn CMMALVideo::GetPicture(DVDVideoPicture* pDvdVideoPicture)
 {
   CSingleLock lock(m_sharedSection);
   MMAL_STATUS_T status;
@@ -776,11 +776,11 @@ int CMMALVideo::GetPicture(DVDVideoPicture* pDvdVideoPicture)
   // we've built up quite a lot of data in decoder - try to throttle it
   double queued = m_decoderPts != DVD_NOPTS_VALUE && m_demuxerPts != DVD_NOPTS_VALUE ? m_demuxerPts - m_decoderPts : 0.0;
   bool full = queued > DVD_MSEC_TO_TIME(1000);
-  int ret = 0;
+  CDVDVideoCodec::VCReturn ret = VC_NONE;
 
   CMMALVideoBuffer *buffer = nullptr;
   XbmcThreads::EndTime delay(500);
-  while (!ret && !delay.IsTimePast())
+  while (ret == VC_NONE && !delay.IsTimePast())
   {
     CSingleLock output_lock(m_output_mutex);
     unsigned int pics = m_output_ready.size();
@@ -798,7 +798,7 @@ int CMMALVideo::GetPicture(DVDVideoPicture* pDvdVideoPicture)
       ret = VC_EOF;
     else if ((m_preroll || pics <= 1) && mmal_queue_length(m_dec_input_pool->queue) > 0)
       ret = VC_BUFFER;
-    if (!ret)
+    if (ret == VC_NONE)
     {
       // otherwise we busy spin
       lock.Leave();

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALCodec.h
@@ -94,9 +94,9 @@ public:
 
   // Required overrides
   virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options);
-  virtual int AddData(const DemuxPacket &packet);
+  virtual bool AddData(const DemuxPacket &packet);
   virtual void Reset(void);
-  virtual int GetPicture(DVDVideoPicture *pDvdVideoPicture);
+  virtual CDVDVideoCodec::VCReturn GetPicture(DVDVideoPicture *pDvdVideoPicture);
   virtual bool ClearPicture(DVDVideoPicture* pDvdVideoPicture);
   virtual unsigned GetAllowedReferences() { return 4; }
   virtual const char* GetName(void) { return m_pFormatName ? m_pFormatName:"mmal-xxx"; }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.cpp
@@ -261,7 +261,7 @@ bool CDecoder::Open(AVCodecContext *avctx, AVCodecContext* mainctx, enum AVPixel
   return true;
 }
 
-int CDecoder::Decode(AVCodecContext* avctx, AVFrame* frame)
+CDVDVideoCodec::VCReturn CDecoder::Decode(AVCodecContext* avctx, AVFrame* frame)
 {
   CSingleLock lock(m_section);
 
@@ -271,19 +271,19 @@ int CDecoder::Decode(AVCodecContext* avctx, AVFrame* frame)
         frame->buf[1] != nullptr || frame->buf[0] == nullptr)
     {
       CLog::Log(LOGERROR, "%s::%s frame format invalid format:%d buf:%p,%p", CLASSNAME, __func__, frame->format, frame->buf[0], frame->buf[1]);
-      return VC_ERROR;
+      return CDVDVideoCodec::VC_ERROR;
     }
     AVBufferRef *buf = frame->buf[0];
     m_gmem = (CGPUMEM *)av_buffer_get_opaque(buf);
   }
-  int status = Check(avctx);
-  if(status)
+  CDVDVideoCodec::VCReturn status = Check(avctx);
+  if (status != CDVDVideoCodec::VC_NONE)
     return status;
 
   if(frame)
-    return VC_BUFFER | VC_PICTURE;
+    return CDVDVideoCodec::VC_PICTURE;
   else
-    return VC_BUFFER;
+    return CDVDVideoCodec::VC_BUFFER;
 }
 
 bool CDecoder::GetPicture(AVCodecContext* avctx, DVDVideoPicture* picture)
@@ -311,10 +311,10 @@ bool CDecoder::GetPicture(AVCodecContext* avctx, DVDVideoPicture* picture)
   return true;
 }
 
-int CDecoder::Check(AVCodecContext* avctx)
+CDVDVideoCodec::VCReturn CDecoder::Check(AVCodecContext* avctx)
 {
   CSingleLock lock(m_section);
-  return 0;
+  return CDVDVideoCodec::VC_NONE;
 }
 
 unsigned CDecoder::GetAllowedReferences()

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/MMALFFmpeg.h
@@ -54,9 +54,9 @@ public:
   CDecoder(CProcessInfo& processInfo, CDVDStreamInfo &hints);
   virtual ~CDecoder();
   virtual bool Open(AVCodecContext* avctx, AVCodecContext* mainctx, const enum AVPixelFormat, unsigned int surfaces);
-  virtual int Decode(AVCodecContext* avctx, AVFrame* frame);
+  virtual CDVDVideoCodec::VCReturn Decode(AVCodecContext* avctx, AVFrame* frame);
   virtual bool GetPicture(AVCodecContext* avctx, DVDVideoPicture* picture);
-  virtual int Check(AVCodecContext* avctx);
+  virtual CDVDVideoCodec::VCReturn Check(AVCodecContext* avctx);
   virtual void Close();
   virtual const std::string Name() { return "mmal"; }
   virtual unsigned GetAllowedReferences();

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VAAPI.h
@@ -418,7 +418,7 @@ public:
   virtual ~CDecoder();
 
   virtual bool Open (AVCodecContext* avctx, AVCodecContext* mainctx, const enum AVPixelFormat, unsigned int surfaces = 0) override;
-  virtual int Decode (AVCodecContext* avctx, AVFrame* frame);
+  virtual CDVDVideoCodec::VCReturn Decode (AVCodecContext* avctx, AVFrame* frame);
   virtual bool GetPicture(AVCodecContext* avctx, DVDVideoPicture* picture) override;
   virtual void Reset() override;
   virtual void Close();
@@ -426,7 +426,7 @@ public:
   virtual bool CanSkipDeint() override;
   virtual unsigned GetAllowedReferences() override { return 4; }
 
-  virtual int Check(AVCodecContext* avctx) override;
+  virtual CDVDVideoCodec::VCReturn Check(AVCodecContext* avctx) override;
   virtual const std::string Name() override { return "vaapi"; }
   virtual void SetCodecControl(int flags) override;
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VDPAU.h
@@ -559,7 +559,7 @@ public:
   virtual ~CDecoder();
 
   virtual bool Open      (AVCodecContext* avctx, AVCodecContext* mainctx, const enum AVPixelFormat, unsigned int surfaces = 0);
-  virtual int  Decode    (AVCodecContext* avctx, AVFrame* frame);
+  virtual CDVDVideoCodec::VCReturn Decode    (AVCodecContext* avctx, AVFrame* frame);
   virtual bool GetPicture(AVCodecContext* avctx, DVDVideoPicture* picture);
   virtual void Reset();
   virtual void Close();
@@ -567,7 +567,7 @@ public:
   virtual bool CanSkipDeint();
   virtual unsigned GetAllowedReferences() { return 5; }
 
-  virtual int  Check(AVCodecContext* avctx);
+  virtual CDVDVideoCodec::VCReturn Check(AVCodecContext* avctx);
   virtual const std::string Name() { return "vdpau"; }
   virtual void SetCodecControl(int flags);
 

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VTB.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VTB.cpp
@@ -101,33 +101,33 @@ bool CDecoder::Open(AVCodecContext *avctx, AVCodecContext* mainctx, enum AVPixel
   return true;
 }
 
-int CDecoder::Decode(AVCodecContext* avctx, AVFrame* frame)
+CDVDVideoCodec::VCReturn CDecoder::Decode(AVCodecContext* avctx, AVFrame* frame)
 {
-  int status = Check(avctx);
+  CDVDVideoCodec::VCReturn status = Check(avctx);
   if(status)
     return status;
 
   if(frame)
   {
     m_renderPicture = (CVPixelBufferRef)frame->data[3];
-    return VC_BUFFER | VC_PICTURE;
+    return CDVDVideoCodec::VC_PICTURE;
   }
   else
-    return VC_BUFFER;
+    return CDVDVideoCodec::VC_BUFFER;
 }
 
 bool CDecoder::GetPicture(AVCodecContext* avctx, DVDVideoPicture* picture)
 {
-  ((CDVDVideoCodecFFmpeg*)avctx->opaque)->GetPictureCommon(picture);
+  ((ICallbackHWAccel*)avctx->opaque)->GetPictureCommon(picture);
 
   picture->format = RENDER_FMT_CVBREF;
   picture->cvBufferRef = m_renderPicture;
   return true;
 }
 
-int CDecoder::Check(AVCodecContext* avctx)
+CDVDVideoCodec::VCReturn CDecoder::Check(AVCodecContext* avctx)
 {
-  return 0;
+  return CDVDVideoCodec::VC_NONE;
 }
 
 unsigned CDecoder::GetAllowedReferences()

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/VTB.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/VTB.h
@@ -36,9 +36,9 @@ public:
  ~CDecoder();
   virtual bool Open(AVCodecContext* avctx, AVCodecContext* mainctx,
                     const enum AVPixelFormat, unsigned int surfaces = 0) override;
-  virtual int Decode(AVCodecContext* avctx, AVFrame* frame) override;
+  virtual CDVDVideoCodec::VCReturn Decode(AVCodecContext* avctx, AVFrame* frame) override;
   virtual bool GetPicture(AVCodecContext* avctx, DVDVideoPicture* picture) override;
-  virtual int Check(AVCodecContext* avctx) override;
+  virtual CDVDVideoCodec::VCReturn Check(AVCodecContext* avctx) override;
   virtual const std::string Name() override { return "vtb"; }
   virtual unsigned GetAllowedReferences() override ;
 

--- a/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
+++ b/xbmc/cores/VideoPlayer/DVDFileInfo.cpp
@@ -215,7 +215,7 @@ bool CDVDFileInfo::ExtractThumb(const std::string &strPath,
       CLog::Log(LOGDEBUG,"%s - seeking to pos %dms (total: %dms) in %s", __FUNCTION__, nSeekTo, nTotalLen, redactPath.c_str());
       if (pDemuxer->SeekTime(nSeekTo, true))
       {
-        int iDecoderState = VC_ERROR;
+        CDVDVideoCodec::VCReturn iDecoderState = CDVDVideoCodec::VC_NONE;
         DVDVideoPicture picture;
 
         memset(&picture, 0, sizeof(picture));
@@ -236,20 +236,17 @@ bool CDVDFileInfo::ExtractThumb(const std::string &strPath,
             continue;
           }
 
-          iDecoderState = pVideoCodec->AddData(*pPacket);
+          pVideoCodec->AddData(*pPacket);
           CDVDDemuxUtils::FreeDemuxPacket(pPacket);
 
-          if (iDecoderState & VC_ERROR)
-            break;
-
-          iDecoderState = 0;
-          while (iDecoderState == 0)
+          iDecoderState = CDVDVideoCodec::VC_NONE;
+          while (iDecoderState == CDVDVideoCodec::VC_NONE)
           {
             memset(&picture, 0, sizeof(DVDVideoPicture));
             iDecoderState = pVideoCodec->GetPicture(&picture);
           }
 
-          if (iDecoderState & VC_PICTURE)
+          if (iDecoderState == CDVDVideoCodec::VC_PICTURE)
           {
             if(!(picture.iFlags & DVP_FLAG_DROPPED))
               break;
@@ -257,7 +254,7 @@ bool CDVDFileInfo::ExtractThumb(const std::string &strPath,
 
         } while (abort_index--);
 
-        if (iDecoderState & VC_PICTURE && !(picture.iFlags & DVP_FLAG_DROPPED))
+        if (iDecoderState == CDVDVideoCodec::VC_PICTURE && !(picture.iFlags & DVP_FLAG_DROPPED))
         {
           {
             unsigned int nWidth = g_advancedSettings.m_imageRes;

--- a/xbmc/cores/VideoPlayer/DVDMessageQueue.h
+++ b/xbmc/cores/VideoPlayer/DVDMessageQueue.h
@@ -76,7 +76,8 @@ public:
   void Abort();
   void End();
 
-  MsgQueueReturnCode Put(CDVDMsg* pMsg, int priority = 0, bool front = true);
+  MsgQueueReturnCode Put(CDVDMsg* pMsg, int priority = 0);
+  MsgQueueReturnCode PutBack(CDVDMsg* pMsg, int priority = 0);
 
   /**
    * msg,       message type from DVDMessage.h
@@ -108,6 +109,10 @@ public:
   bool IsDataBased() const;
 
 private:
+
+  MsgQueueReturnCode Put(CDVDMsg* pMsg, int priority, bool front);
+  void UpdateTimeFront();
+  void UpdateTimeBack();
 
   CEvent m_hEvent;
   mutable CCriticalSection m_section;


### PR DESCRIPTION
cleanup interface for video decoder

this should make clear that:

- the old way of combining flags is history
- videoplayer calls GetPicture on every cycle
- GetPicture controls the process
- decoder has to consume the entire demux packet

@peak3d @popcornmix ping