### PR TITLE
[addons] fix installed add-on location search

### DIFF
--- a/xbmc/addons/AddonInfo.cpp
+++ b/xbmc/addons/AddonInfo.cpp
@@ -290,7 +290,8 @@ CAddonInfo::CAddonInfo(std::string addonPath)
     m_type(ADDON_UNKNOWN),
     m_path(addonPath)
 {
-  auto addonXmlPath = CSpecialProtocol::TranslatePath(URIUtils::AddFileToFolder(m_path, "addon.xml"));
+  m_path = CSpecialProtocol::TranslatePath(addonPath);
+  auto addonXmlPath = URIUtils::AddFileToFolder(m_path, "addon.xml");
 
   CXBMCTinyXML xmlDoc;
   if (!xmlDoc.LoadFile(addonXmlPath))


### PR DESCRIPTION
After the change to new system was Kodi's "special://" used, with them
comes a problem to locate present installed libraries e.g on
'/usr/local/lib/kodi/addons/*'.

This translate the path on creation of CAddonInfo and prevent the
problems on add-on load.