### PR TITLE
FFmpegImage: Use avcodec_close should not be used anymore replace wit…

### DIFF
--- a/xbmc/guilib/FFmpegImage.cpp
+++ b/xbmc/guilib/FFmpegImage.cpp
@@ -80,7 +80,6 @@ struct ThumbDataManagement
     frame_input = nullptr;
     av_frame_free(&frame_temporary);
     frame_temporary = nullptr;
-    avcodec_close(avOutctx);
     avcodec_free_context(&avOutctx);
     avOutctx = nullptr;
     sws_freeContext(sws);


### PR DESCRIPTION
…h avcodec_free_context

Spotted this

```
Do not use this function. Use avcodec_free_context() to destroy a codec context (either open or closed). Opening and closing a codec context multiple times is not supported anymore – use multiple codec contexts instead.
```