### PR TITLE
[addons] add multiple instance support to Kodi

### DIFF
--- a/xbmc/addons/AddonInfo.h
+++ b/xbmc/addons/AddonInfo.h
@@ -28,6 +28,7 @@
 #include <set>
 #include <stdlib.h>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 class TiXmlElement;
@@ -165,6 +166,20 @@ namespace ADDON
     std::set<TYPE> m_providedSubContent;
   };
 
+  class IAddonInstanceHandler
+  {
+  public:
+    IAddonInstanceHandler(TYPE type) : m_type(type) { }
+
+    TYPE UsedType() { return m_type; }
+
+  private:
+    TYPE m_type;
+  };
+
+  class CAddonMgr;
+  class CAddonDll;
+  typedef std::shared_ptr<CAddonDll> AddonDllPtr;
   class AddonVersion;
   typedef std::map<std::string, std::pair<const AddonVersion, bool> > ADDONDEPS;
 
@@ -564,6 +579,24 @@ namespace ADDON
      * @return true if successfully done, otherwise false
      */
     bool LoadAddonXML(const TiXmlElement* element, std::string addonXmlPath);
+
+  /*!
+   * @brief active addon handle parts
+   *
+   * This area contains the created addon class and all active instances of the
+   * add-on. If active ones are empty becomes the pointer reseted. For this
+   * reasons is CAddonMgr added as friend here and the private separated from
+   * the rest.
+   *
+   * @todo the AddonDllPtr need to removed in future and everything done only
+   * with AddonPtr.
+   */
+  //@{
+  private:
+    friend class CAddonMgr;
+    AddonDllPtr m_activeAddon;
+    std::unordered_set<const IAddonInstanceHandler*> m_activeAddonHandlers;
+  //@}
   };
 
 } /* namespace ADDON */

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -78,6 +78,12 @@ namespace ADDON
      */
     bool GetAddon(const std::string &addonId, AddonPtr &addon, const TYPE &type = ADDON_UNKNOWN);
 
+    /// @todo New parts to handle multi instance addon, still in todo
+    //@{
+    AddonDllPtr GetAddon(const std::string &addonId, const IAddonInstanceHandler* handler);
+    void ReleaseAddon(AddonDllPtr& addon, const IAddonInstanceHandler* handler);
+    //@}
+
     AddonDllPtr GetAddon(const TYPE &type, const std::string &id);    
 
     /*!

--- a/xbmc/guilib/GUIVisualisationControl.cpp
+++ b/xbmc/guilib/GUIVisualisationControl.cpp
@@ -72,6 +72,7 @@ void CAudioBuffer::Set(const float* psBuffer, int iSize)
 
 CGUIVisualisationControl::CGUIVisualisationControl(int parentID, int controlID, float posX, float posY, float width, float height)
   : CGUIControl(parentID, controlID, posX, posY, width, height),
+    IAddonInstanceHandler(ADDON_VIZ),
     m_callStart(false),
     m_alreadyStarted(false),
     m_attemptedLoad(false),
@@ -84,6 +85,7 @@ CGUIVisualisationControl::CGUIVisualisationControl(int parentID, int controlID, 
 
 CGUIVisualisationControl::CGUIVisualisationControl(const CGUIVisualisationControl &from)
   : CGUIControl(from),
+    IAddonInstanceHandler(ADDON_VIZ),
     m_callStart(false),
     m_alreadyStarted(false),
     m_attemptedLoad(false),
@@ -398,7 +400,7 @@ bool CGUIVisualisationControl::InitVisualization()
   if (x + w > g_graphicsContext.GetWidth()) w = g_graphicsContext.GetWidth() - x;
   if (y + h > g_graphicsContext.GetHeight()) h = g_graphicsContext.GetHeight() - y;
 
-  m_addon = CAddonMgr::GetInstance().GetAddon(ADDON_VIZ, CServiceBroker::GetSettings().GetString(CSettings::SETTING_MUSICPLAYER_VISUALISATION));
+  m_addon = CAddonMgr::GetInstance().GetAddon(CServiceBroker::GetSettings().GetString(CSettings::SETTING_MUSICPLAYER_VISUALISATION), this);
   if (!m_addon)
   {
     g_graphicsContext.ApplyStateBlock();
@@ -470,7 +472,7 @@ void CGUIVisualisationControl::DeInitVisualization()
   if (m_addon)
   {
     m_addon->DestroyInstance(m_addon->ID());
-    m_addon.reset();
+    CAddonMgr::GetInstance().ReleaseAddon(m_addon, this);
   }
 
   memset(&m_struct, 0, sizeof(m_struct));

--- a/xbmc/guilib/GUIVisualisationControl.h
+++ b/xbmc/guilib/GUIVisualisationControl.h
@@ -41,7 +41,7 @@ private:
   int m_iLen;
 };
 
-class CGUIVisualisationControl : public CGUIControl, public IAudioCallback
+class CGUIVisualisationControl : public CGUIControl, public ADDON::IAddonInstanceHandler, public IAudioCallback
 {
 public:
   CGUIVisualisationControl(int parentID, int controlID, float posX, float posY, float width, float height);

--- a/xbmc/windows/GUIWindowScreensaver.cpp
+++ b/xbmc/windows/GUIWindowScreensaver.cpp
@@ -33,6 +33,7 @@ using namespace ADDON;
 
 CGUIWindowScreensaver::CGUIWindowScreensaver(void)
   : CGUIWindow(WINDOW_SCREENSAVER, ""),
+    IAddonInstanceHandler(ADDON_SCREENSAVER),
     m_addon(nullptr)
 {
   memset(&m_struct, 0, sizeof(m_struct));
@@ -78,7 +79,7 @@ bool CGUIWindowScreensaver::OnMessage(CGUIMessage& message)
       if (m_addon)
       {
         m_addon->DestroyInstance(m_addon->ID());
-        m_addon.reset();
+        CAddonMgr::GetInstance().ReleaseAddon(m_addon, this);
       }
 
       memset(&m_struct, 0, sizeof(m_struct));
@@ -94,7 +95,7 @@ bool CGUIWindowScreensaver::OnMessage(CGUIMessage& message)
 
       g_graphicsContext.CaptureStateBlock();
 
-      m_addon = CAddonMgr::GetInstance().GetAddon(ADDON_SCREENSAVER, CServiceBroker::GetSettings().GetString(CSettings::SETTING_SCREENSAVER_MODE));
+      m_addon = CAddonMgr::GetInstance().GetAddon(CServiceBroker::GetSettings().GetString(CSettings::SETTING_SCREENSAVER_MODE), this);
       if (!m_addon)
         return false;
 

--- a/xbmc/windows/GUIWindowScreensaver.h
+++ b/xbmc/windows/GUIWindowScreensaver.h
@@ -23,7 +23,7 @@
 #include "addons/AddonDll.h"
 #include "guilib/GUIWindow.h"
 
-class CGUIWindowScreensaver : public CGUIWindow
+class CGUIWindowScreensaver : public CGUIWindow, public ADDON::IAddonInstanceHandler
 {
 public:
   CGUIWindowScreensaver(void);


### PR DESCRIPTION
This add the support to handle multiple instances together on one
add-on.

A addon class stays so long created as it is used by instances,
after the last instance release it becomes the addon class destroyed.

Further stays the data on CAddonDll and if them call for a type an
"CreateInstance" on add-on becomes also the first time a "Create"
performed, every other "CreateInstance" call do know that the
"Create" is already done and becomes skipped.