### PR TITLE
[addons] add support to create child instance from parent

### DIFF
--- a/xbmc/addons/AddonDll.cpp
+++ b/xbmc/addons/AddonDll.cpp
@@ -336,7 +336,7 @@ void CAddonDll::Destroy()
     /* Make sure all instances are destroyed if interface becomes stopped. */
     for (std::map<std::string, std::pair<int, KODI_HANDLE>>::iterator it = m_usedInstances.begin(); it != m_usedInstances.end(); ++it)
     {
-      m_pDll->DestroyInstance(it->second.first, it->second.second);
+      m_interface.toAddon.destroy_instance(it->second.first, it->second.second);
       m_usedInstances.erase(it);
     }
 
@@ -388,7 +388,7 @@ bool CAddonDll::CheckAPIVersion(int type)
 }
 
 /*! @todo there comes further changes until it is final! */
-ADDON_STATUS CAddonDll::CreateInstance(int instanceType, const std::string& instanceID, KODI_HANDLE instance, KODI_HANDLE* addonInstance)
+ADDON_STATUS CAddonDll::CreateInstance(int instanceType, const std::string& instanceID, KODI_HANDLE instance, KODI_HANDLE* addonInstance, KODI_HANDLE parentInstance)
 {
   ADDON_STATUS status = ADDON_STATUS_OK;
 
@@ -401,7 +401,7 @@ ADDON_STATUS CAddonDll::CreateInstance(int instanceType, const std::string& inst
   if (!CheckAPIVersion(instanceType))
     return ADDON_STATUS_PERMANENT_FAILURE;
 
-  status = m_pDll->CreateInstance(instanceType, instanceID.c_str(), instance, addonInstance);
+  status = m_interface.toAddon.create_instance(instanceType, instanceID.c_str(), instance, addonInstance, parentInstance);
   if (status == ADDON_STATUS_OK)
   {
     m_usedInstances[instanceID] = std::make_pair(instanceType, *addonInstance);
@@ -416,7 +416,7 @@ void CAddonDll::DestroyInstance(const std::string& instanceID)
   std::map<std::string, std::pair<int, KODI_HANDLE>>::iterator it = m_usedInstances.find(instanceID);
   if (it != m_usedInstances.end())
   {
-    m_pDll->DestroyInstance(it->second.first, it->second.second);
+    m_interface.toAddon.destroy_instance(it->second.first, it->second.second);
     m_usedInstances.erase(it);
   }
 

--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -51,7 +51,7 @@ namespace ADDON
 
     bool DllLoaded(void) const;
 
-    ADDON_STATUS CreateInstance(int instanceType, const std::string& instanceID, KODI_HANDLE instance, KODI_HANDLE* addonInstance);
+    ADDON_STATUS CreateInstance(int instanceType, const std::string& instanceID, KODI_HANDLE instance, KODI_HANDLE* addonInstance, KODI_HANDLE parentInstance = nullptr);
     void DestroyInstance(const std::string& instanceID);
 
     virtual void UpdateSettings(std::map<std::string, std::string>& settings);

--- a/xbmc/addons/DllAddon.h
+++ b/xbmc/addons/DllAddon.h
@@ -32,8 +32,6 @@ public:
   virtual ADDON_STATUS GetStatus() =0;
   virtual ADDON_STATUS SetSetting(const char *settingName, const void *settingValue) =0;
   virtual const char* GetAddonTypeVersion(int type)=0;
-  virtual ADDON_STATUS CreateInstance(int instanceType, const char* instanceID, KODI_HANDLE instance, KODI_HANDLE* addonInstance) =0;
-  virtual void DestroyInstance(int instanceType, KODI_HANDLE instance) =0;
 };
 
 class DllAddon : public DllDynamic, public DllAddonInterface
@@ -46,8 +44,6 @@ public:
   DEFINE_METHOD2(ADDON_STATUS, SetSetting, (const char *p1, const void *p2))
   DEFINE_METHOD1(void, GetAddon, (void* p1))
   DEFINE_METHOD1(const char*, GetAddonTypeVersion, (int p1))
-  DEFINE_METHOD4(ADDON_STATUS, CreateInstance, (int p1, const char* p2, KODI_HANDLE p3, KODI_HANDLE* p4))
-  DEFINE_METHOD2(void, DestroyInstance, (int p1, KODI_HANDLE p2))
   BEGIN_METHOD_RESOLVE()
     RESOLVE_METHOD_RENAME(get_addon,GetAddon)
     RESOLVE_METHOD_RENAME(ADDON_Create, Create)
@@ -55,8 +51,6 @@ public:
     RESOLVE_METHOD_RENAME(ADDON_GetStatus, GetStatus)
     RESOLVE_METHOD_RENAME(ADDON_SetSetting, SetSetting)
     RESOLVE_METHOD_RENAME(ADDON_GetTypeVersion, GetAddonTypeVersion)
-    RESOLVE_METHOD_RENAME(ADDON_CreateInstance, CreateInstance)
-    RESOLVE_METHOD_RENAME(ADDON_DestroyInstance, DestroyInstance)
   END_METHOD_RESOLVE()
 };
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/versions.h
@@ -43,14 +43,14 @@
 
 #define ADDON_INSTANCE_VERSION_ADSP                   "0.1.10"
 #define ADDON_INSTANCE_VERSION_AUDIODECODER           "1.0.1"
-#define ADDON_INSTANCE_VERSION_AUDIOENCODER           "1.0.1"
+#define ADDON_INSTANCE_VERSION_AUDIOENCODER           "1.0.2"
 #define ADDON_INSTANCE_VERSION_GAME                   "1.0.30"
 #define ADDON_INSTANCE_VERSION_IMAGEDECODER           "1.0.0"
-#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "1.0.8"
+#define ADDON_INSTANCE_VERSION_INPUTSTREAM            "1.0.9"
 #define ADDON_INSTANCE_VERSION_PERIPHERAL             "1.3.0"
 #define ADDON_INSTANCE_VERSION_PVR                    "5.2.3"
-#define ADDON_INSTANCE_VERSION_SCREENSAVER            "1.0.1"
-#define ADDON_INSTANCE_VERSION_VISUALIZATION          "1.0.1"
+#define ADDON_INSTANCE_VERSION_SCREENSAVER            "1.0.2"
+#define ADDON_INSTANCE_VERSION_VISUALIZATION          "1.0.2"
 
 /*
  * The currently used types for Kodi add-ons


### PR DESCRIPTION
This add a parent instance pointer to the addon CreateInstance call.

If a parent pointer is set becomes the CreateInstance of them called,
otherwise them from base.