### PR TITLE
[addons] reduce amount of parts on add-on instance classes

### DIFF
--- a/xbmc/addons/AddonDll.cpp
+++ b/xbmc/addons/AddonDll.cpp
@@ -42,18 +42,21 @@
 namespace ADDON
 {
 
-IAddonInstanceHandler::IAddonInstanceHandler(TYPE type)
+IAddonInstanceHandler::IAddonInstanceHandler(TYPE type, const std::string& instanceID/* = ""*/)
   : m_type(type),
-    m_uuid(StringUtils::CreateUUID())
+    m_parentInstance(nullptr)
 {
+  m_instanceId = !instanceID.empty() ? instanceID : StringUtils::Format("%p", this);
 }
 
-IAddonInstanceHandler::IAddonInstanceHandler(TYPE type, const AddonInfoPtr& addonInfo)
+IAddonInstanceHandler::IAddonInstanceHandler(TYPE type, const AddonInfoPtr& addonInfo, kodi::addon::IAddonInstance* parentInstance/* = nullptr*/, const std::string& instanceID/* = ""*/)
   : m_type(type),
-    m_uuid(StringUtils::CreateUUID()),
+    m_parentInstance(parentInstance),
     m_addonInfo(addonInfo)
 {
-  m_addon = CAddonMgr::GetInstance().GetAddon(addonInfo->ID(), this);
+  m_instanceId = !instanceID.empty() ? instanceID : StringUtils::Format("%p", this);
+
+  m_addon = CAddonMgr::GetInstance().GetAddon(addonInfo, this);
   if (!m_addon)
     CLog::Log(LOGFATAL, "ADDON::IAddonInstanceHandler: Tried to get add-on '%s' who not available!", addonInfo->ID().c_str());
 }
@@ -64,14 +67,14 @@ IAddonInstanceHandler::~IAddonInstanceHandler()
     CAddonMgr::GetInstance().ReleaseAddon(m_addon, this);
 }
 
-bool IAddonInstanceHandler::CreateInstance(int instanceType, const std::string& instanceID, KODI_HANDLE instance, KODI_HANDLE* addonInstance, KODI_HANDLE parentInstance/* = nullptr*/)
+bool IAddonInstanceHandler::CreateInstance(int instanceType, KODI_HANDLE instance, KODI_HANDLE* addonInstance)
 {
-  return m_addon->CreateInstance(instanceType, instanceID, instance, addonInstance, parentInstance) == ADDON_STATUS_OK;
+  return m_addon->CreateInstance(instanceType, m_instanceId, instance, addonInstance, m_parentInstance) == ADDON_STATUS_OK;
 }
 
-void IAddonInstanceHandler::DestroyInstance(const std::string& instanceID)
+void IAddonInstanceHandler::DestroyInstance()
 {
-  m_addon->DestroyInstance(instanceID);
+  m_addon->DestroyInstance(m_instanceId);
 }
 
 CAddonDll::CAddonDll(AddonInfoPtr props)

--- a/xbmc/addons/AddonDll.cpp
+++ b/xbmc/addons/AddonDll.cpp
@@ -42,6 +42,38 @@
 namespace ADDON
 {
 
+IAddonInstanceHandler::IAddonInstanceHandler(TYPE type)
+  : m_type(type),
+    m_uuid(StringUtils::CreateUUID())
+{
+}
+
+IAddonInstanceHandler::IAddonInstanceHandler(TYPE type, const AddonInfoPtr& addonInfo)
+  : m_type(type),
+    m_uuid(StringUtils::CreateUUID()),
+    m_addonInfo(addonInfo)
+{
+  m_addon = CAddonMgr::GetInstance().GetAddon(addonInfo->ID(), this);
+  if (!m_addon)
+    CLog::Log(LOGFATAL, "ADDON::IAddonInstanceHandler: Tried to get add-on '%s' who not available!", addonInfo->ID().c_str());
+}
+
+IAddonInstanceHandler::~IAddonInstanceHandler()
+{
+  if (m_addon)
+    CAddonMgr::GetInstance().ReleaseAddon(m_addon, this);
+}
+
+bool IAddonInstanceHandler::CreateInstance(int instanceType, const std::string& instanceID, KODI_HANDLE instance, KODI_HANDLE* addonInstance, KODI_HANDLE parentInstance/* = nullptr*/)
+{
+  return m_addon->CreateInstance(instanceType, instanceID, instance, addonInstance, parentInstance) == ADDON_STATUS_OK;
+}
+
+void IAddonInstanceHandler::DestroyInstance(const std::string& instanceID)
+{
+  m_addon->DestroyInstance(instanceID);
+}
+
 CAddonDll::CAddonDll(AddonInfoPtr props)
   : CAddon(props),
     m_bIsChild(false)

--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -31,6 +31,28 @@ namespace ADDON
   class CAddonDll;
   typedef std::shared_ptr<CAddonDll> AddonDllPtr;
 
+  class IAddonInstanceHandler
+  {
+  public:
+    IAddonInstanceHandler(TYPE type);
+    IAddonInstanceHandler(TYPE type, const AddonInfoPtr& addonInfo);
+    virtual ~IAddonInstanceHandler();
+
+    TYPE UsedType() { return m_type; }
+    const std::string& UUID() { return m_uuid; }
+    const AddonInfoPtr& AddonInfo() { return m_addonInfo; }
+
+    bool CreateInstance(int instanceType, const std::string& instanceID, KODI_HANDLE instance, KODI_HANDLE* addonInstance, KODI_HANDLE parentInstance = nullptr);
+    void DestroyInstance(const std::string& instanceID);
+    const AddonDllPtr& Addon() { return m_addon; }
+
+  private:
+    TYPE m_type;
+    std::string m_uuid;
+    AddonInfoPtr m_addonInfo;
+    AddonDllPtr m_addon;
+  };
+
   class CAddonDll : public CAddon
   {
   public:

--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -34,21 +34,22 @@ namespace ADDON
   class IAddonInstanceHandler
   {
   public:
-    IAddonInstanceHandler(TYPE type);
-    IAddonInstanceHandler(TYPE type, const AddonInfoPtr& addonInfo);
+    IAddonInstanceHandler(TYPE type, const std::string& instanceID = "");
+    IAddonInstanceHandler(TYPE type, const AddonInfoPtr& addonInfo, kodi::addon::IAddonInstance* parentInstance = nullptr, const std::string& instanceID = "");
     virtual ~IAddonInstanceHandler();
 
     TYPE UsedType() { return m_type; }
-    const std::string& UUID() { return m_uuid; }
+    const std::string& InstanceID() { return m_instanceId; }
     const AddonInfoPtr& AddonInfo() { return m_addonInfo; }
 
-    bool CreateInstance(int instanceType, const std::string& instanceID, KODI_HANDLE instance, KODI_HANDLE* addonInstance, KODI_HANDLE parentInstance = nullptr);
-    void DestroyInstance(const std::string& instanceID);
+    bool CreateInstance(int instanceType, KODI_HANDLE instance, KODI_HANDLE* addonInstance);
+    void DestroyInstance();
     const AddonDllPtr& Addon() { return m_addon; }
 
   private:
     TYPE m_type;
-    std::string m_uuid;
+    std::string m_instanceId;
+    kodi::addon::IAddonInstance* m_parentInstance;
     AddonInfoPtr m_addonInfo;
     AddonDllPtr m_addon;
   };

--- a/xbmc/addons/AddonDll.h
+++ b/xbmc/addons/AddonDll.h
@@ -114,27 +114,5 @@ namespace ADDON
     //@}
   };
 
-  /*!
-   * Class to make use of standard add-on functions more easy available on
-   * Kodi's add-on instance classes.
-   *
-   * This functions in class are needed on several places, without them must be
-   * on every instance class the same function added, with them can it be
-   * prevent.
-   */
-  class CAddonInstanceInfo
-  {
-  public:
-    CAddonInstanceInfo(AddonDllPtr addon) : m_addon(addon) { }
-
-    std::string ID() const { return m_addon->ID(); }
-    std::string Name() const { return m_addon->Name(); }
-    std::string Path() const { return m_addon->Path(); }
-    std::string Profile() const { return m_addon->Profile(); }
-
-  protected:
-    ADDON::AddonDllPtr m_addon;
-  };
-
 }; /* namespace ADDON */
 

--- a/xbmc/addons/AddonInfo.h
+++ b/xbmc/addons/AddonInfo.h
@@ -168,20 +168,11 @@ namespace ADDON
     std::set<TYPE> m_providedSubContent;
   };
 
-  class IAddonInstanceHandler
-  {
-  public:
-    IAddonInstanceHandler(TYPE type) : m_type(type) { }
-
-    TYPE UsedType() { return m_type; }
-
-  private:
-    TYPE m_type;
-  };
-
+  class IAddonInstanceHandler;
   class CAddonMgr;
   class CAddonDll;
   typedef std::shared_ptr<CAddonDll> AddonDllPtr;
+
   class AddonVersion;
   typedef std::map<std::string, std::pair<const AddonVersion, bool> > ADDONDEPS;
 

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -80,7 +80,8 @@ namespace ADDON
 
     /// @todo New parts to handle multi instance addon, still in todo
     //@{
-    AddonDllPtr GetAddon(const std::string &addonId, const IAddonInstanceHandler* handler);
+    AddonDllPtr GetAddon(const std::string& addonId, const IAddonInstanceHandler* handler);
+    AddonDllPtr GetAddon(const AddonInfoPtr& addonInfo, const IAddonInstanceHandler* handler);
     void ReleaseAddon(AddonDllPtr& addon, const IAddonInstanceHandler* handler);
     //@}
 

--- a/xbmc/addons/AudioEncoder.cpp
+++ b/xbmc/addons/AudioEncoder.cpp
@@ -32,7 +32,7 @@ CAudioEncoder::CAudioEncoder(AddonInfoPtr addonInfo)
 bool CAudioEncoder::Init(AddonToKodiFuncTable_AudioEncoder &callbacks)
 {
   m_struct.toKodi = callbacks;
-  if (!CreateInstance(ADDON_INSTANCE_AUDIOENCODER, UUID(), &m_struct, reinterpret_cast<KODI_HANDLE*>(&m_addonInstance)) || !m_struct.toAddon.Start)
+  if (!CreateInstance(ADDON_INSTANCE_AUDIOENCODER, &m_struct, reinterpret_cast<KODI_HANDLE*>(&m_addonInstance)) || !m_struct.toAddon.Start)
     return false;
 
   return m_struct.toAddon.Start(m_addonInstance,
@@ -63,7 +63,7 @@ bool CAudioEncoder::Close()
   if (m_struct.toAddon.Finish)
     ret = m_struct.toAddon.Finish(m_addonInstance);
 
-  DestroyInstance(UUID());
+  DestroyInstance();
   memset(&m_struct, 0, sizeof(m_struct));
 
   return ret;

--- a/xbmc/addons/AudioEncoder.cpp
+++ b/xbmc/addons/AudioEncoder.cpp
@@ -24,24 +24,15 @@ namespace ADDON
 {
 
 CAudioEncoder::CAudioEncoder(AddonInfoPtr addonInfo)
-  : IAddonInstanceHandler(ADDON_AUDIOENCODER)
+  : IAddonInstanceHandler(ADDON_AUDIOENCODER, addonInfo)
 {
-  m_addon = CAddonMgr::GetInstance().GetAddon(addonInfo->ID(), this);
-  if (!m_addon)
-    CLog::Log(LOGFATAL, "ADDON::CAudioEncoder: Tried to get add-on '%s' who not available!", addonInfo->ID().c_str());
-
   memset(&m_struct, 0, sizeof(m_struct));
-}
-
-CAudioEncoder::~CAudioEncoder()
-{
-  CAddonMgr::GetInstance().ReleaseAddon(m_addon, this);
 }
 
 bool CAudioEncoder::Init(AddonToKodiFuncTable_AudioEncoder &callbacks)
 {
   m_struct.toKodi = callbacks;
-  if (m_addon->CreateInstance(ADDON_INSTANCE_AUDIOENCODER, m_addon->ID(), &m_struct, reinterpret_cast<KODI_HANDLE*>(&m_addonInstance)) != ADDON_STATUS_OK || !m_struct.toAddon.Start)
+  if (!CreateInstance(ADDON_INSTANCE_AUDIOENCODER, UUID(), &m_struct, reinterpret_cast<KODI_HANDLE*>(&m_addonInstance)) || !m_struct.toAddon.Start)
     return false;
 
   return m_struct.toAddon.Start(m_addonInstance,
@@ -72,7 +63,7 @@ bool CAudioEncoder::Close()
   if (m_struct.toAddon.Finish)
     ret = m_struct.toAddon.Finish(m_addonInstance);
 
-  m_addon->DestroyInstance(m_addon->ID());
+  DestroyInstance(UUID());
   memset(&m_struct, 0, sizeof(m_struct));
 
   return ret;

--- a/xbmc/addons/AudioEncoder.h
+++ b/xbmc/addons/AudioEncoder.h
@@ -28,7 +28,6 @@ namespace ADDON
   {
   public:
     CAudioEncoder(AddonInfoPtr addonInfo);
-    virtual ~CAudioEncoder();
 
     // Child functions related to IEncoder
     bool Init(AddonToKodiFuncTable_AudioEncoder& callbacks);

--- a/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSP.cpp
+++ b/xbmc/cores/AudioEngine/Engines/ActiveAE/AudioDSPAddons/ActiveAEDSP.cpp
@@ -620,7 +620,9 @@ void CActiveAEDSP::UpdateAddons()
       }
       else
       {
-        dspAddon = std::dynamic_pointer_cast<CActiveAEDSPAddon>(CAddonMgr::GetInstance().GetAddon(ADDON_ADSPDLL, addonInfo->ID()));
+        AddonPtr addon;
+        CAddonMgr::GetInstance().GetAddon(addonInfo->ID(), addon, ADDON_ADSPDLL);
+        dspAddon = std::dynamic_pointer_cast<CActiveAEDSPAddon>(addon);
         if (!dspAddon)
         {
           CLog::Log(LOGERROR, "CActiveAEDSP::UpdateAndInitialiseAddons - severe error, incorrect add type");
@@ -640,7 +642,9 @@ void CActiveAEDSP::UpdateAddons()
     else if (!bEnabled && IsKnownAudioDSPAddon(addonInfo))
     {
       CLog::Log(LOGDEBUG, "Disabling AudioDSP add-on: %s", addonInfo->ID().c_str());
-      dspAddon = std::dynamic_pointer_cast<CActiveAEDSPAddon>(CAddonMgr::GetInstance().GetAddon(ADDON_ADSPDLL, addonInfo->ID()));
+      AddonPtr addon;
+      CAddonMgr::GetInstance().GetAddon(addonInfo->ID(), addon, ADDON_ADSPDLL);
+      dspAddon = std::dynamic_pointer_cast<CActiveAEDSPAddon>(addon);
     
       CSingleLock lock(m_critSection);
       AE_DSP_ADDONMAP::iterator iter = m_addonMap.find(dspAddon->GetID());

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
@@ -33,9 +33,9 @@ CAddonVideoCodec::CAddonVideoCodec(CProcessInfo &processInfo, ADDON::AddonInfoPt
 {
   memset(&m_struct, 0, sizeof(m_struct));
   m_struct.toKodi.kodiInstance = this;
-  if (!CreateInstance(ADDON_INSTANCE_INPUTSTREAM, UUID(), &m_struct, reinterpret_cast<KODI_HANDLE*>(&m_addonInstance), m_parentInstance) || !m_struct.toAddon.Open)
+  if (!CreateInstance(ADDON_INSTANCE_VIDEOCODEC, UUID(), &m_struct, reinterpret_cast<KODI_HANDLE*>(&m_addonInstance), m_parentInstance) || !m_struct.toAddon.Open)
   {
-    CLog::Log(LOGERROR, "CInputStreamAddon: Failed to create add-on instance for '%s'", addonInfo->ID().c_str());
+    CLog::Log(LOGERROR, "CAddonVideoCodec: Failed to create add-on instance for '%s'", addonInfo->ID().c_str());
     return;
   }
 }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.cpp
@@ -28,12 +28,11 @@ using namespace ADDON;
 
 CAddonVideoCodec::CAddonVideoCodec(CProcessInfo &processInfo, ADDON::AddonInfoPtr& addonInfo, kodi::addon::IAddonInstance* parentInstance)
   : CDVDVideoCodec(processInfo),
-  IAddonInstanceHandler(ADDON::ADDON_VIDEOCODEC, addonInfo),
-  m_parentInstance(parentInstance)
+    IAddonInstanceHandler(ADDON::ADDON_VIDEOCODEC, addonInfo, parentInstance)
 {
   memset(&m_struct, 0, sizeof(m_struct));
   m_struct.toKodi.kodiInstance = this;
-  if (!CreateInstance(ADDON_INSTANCE_VIDEOCODEC, UUID(), &m_struct, reinterpret_cast<KODI_HANDLE*>(&m_addonInstance), m_parentInstance) || !m_struct.toAddon.Open)
+  if (!CreateInstance(ADDON_INSTANCE_VIDEOCODEC, &m_struct, reinterpret_cast<KODI_HANDLE*>(&m_addonInstance)) || !m_struct.toAddon.Open)
   {
     CLog::Log(LOGERROR, "CAddonVideoCodec: Failed to create add-on instance for '%s'", addonInfo->ID().c_str());
     return;
@@ -42,7 +41,7 @@ CAddonVideoCodec::CAddonVideoCodec(CProcessInfo &processInfo, ADDON::AddonInfoPt
 
 CAddonVideoCodec::~CAddonVideoCodec()
 {
-  DestroyInstance(UUID());
+  DestroyInstance();
 }
 
 bool CAddonVideoCodec::CopyToInitData(VIDEOCODEC_INITDATA &initData, CDVDStreamInfo &hints)

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.h
@@ -29,7 +29,7 @@ class CAddonVideoCodec
 {
 public:
   CAddonVideoCodec(CProcessInfo &processInfo, ADDON::AddonInfoPtr& addonInfo, kodi::addon::IAddonInstance* parentInstance);
-  ~CAddonVideoCodec();
+  virtual ~CAddonVideoCodec();
 
   virtual bool Open(CDVDStreamInfo &hints, CDVDCodecOptions &options) override;
   virtual bool Reconfigure(CDVDStreamInfo &hints) override;
@@ -43,7 +43,6 @@ private:
 
   kodi::addon::CInstanceVideoCodec* m_addonInstance;
   AddonInstance_VideoCodec m_struct;
-  kodi::addon::IAddonInstance* m_parentInstance;
   
   int m_codecFlags;
   VIDEOCODEC_FORMAT m_formats[VIDEOCODEC_FORMAT::MaxVideoFormats + 1];

--- a/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.h
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/Video/AddonVideoCodec.h
@@ -41,8 +41,6 @@ public:
 private:
   bool CopyToInitData(VIDEOCODEC_INITDATA &initData, CDVDStreamInfo &hints);
 
-  std::string m_id;
-  ADDON::AddonDllPtr m_addon;
   kodi::addon::CInstanceVideoCodec* m_addonInstance;
   AddonInstance_VideoCodec m_struct;
   kodi::addon::IAddonInstance* m_parentInstance;

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.cpp
@@ -128,7 +128,7 @@ bool CInputStreamAddon::Open()
   m_struct.toKodi.FreeDemuxPacket = InputStreamFreeDemuxPacket;
   m_struct.toKodi.AllocateDemuxPacket = InputStreamAllocateDemuxPacket;
   m_struct.toKodi.AllocateEncryptedDemuxPacket = InputStreamAllocateEncryptedDemuxPacket;
-  if (!CreateInstance(ADDON_INSTANCE_INPUTSTREAM, UUID(), &m_struct, reinterpret_cast<KODI_HANDLE*>(&m_addonInstance)) || !m_struct.toAddon.Open)
+  if (!CreateInstance(ADDON_INSTANCE_INPUTSTREAM, &m_struct, reinterpret_cast<KODI_HANDLE*>(&m_addonInstance)) || !m_struct.toAddon.Open)
     return false;
 
   INPUTSTREAM props;
@@ -176,7 +176,7 @@ void CInputStreamAddon::Close()
 {
   if (m_struct.toAddon.Close)
     m_struct.toAddon.Close(m_addonInstance);
-  DestroyInstance(UUID());
+  DestroyInstance();
   memset(&m_struct, 0, sizeof(m_struct));
 }
 

--- a/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
+++ b/xbmc/cores/VideoPlayer/DVDInputStreams/InputStreamAddon.h
@@ -118,8 +118,6 @@ private:
   INPUTSTREAM_CAPABILITIES m_caps;
   std::map<int, CDemuxStream*> m_streams;
 
-  ADDON::AddonInfoPtr m_addonInfo;
-  ADDON::AddonDllPtr m_addon;
   kodi::addon::CInstanceInputStream* m_addonInstance;
   AddonInstance_InputStream m_struct;
   std::shared_ptr<CInputStreamProvider> m_subAddonProvider;


### PR DESCRIPTION
With this change becomes the standard parts done on the parent
class IAddonInstanceHandler.

About screensaver and visualization is it not possible to use
this parts and need to find a better way to prevent problems if the
same way becomes used somewhere else.
