### PR TITLE
[addons] fix save if hidden settings are present

### DIFF
--- a/xbmc/addons/Addon.cpp
+++ b/xbmc/addons/Addon.cpp
@@ -186,7 +186,8 @@ void CAddon::UpdateSetting(const std::string& key, const std::string& value)
 void CAddon::UpdateSettings(std::map<std::string, std::string>& settings)
 {
   LoadSettings();
-  m_settings = settings;
+  for (const auto& setting : settings)
+    m_settings[setting.first] = setting.second;
 }
 
 bool CAddon::SettingsFromXML(const CXBMCTinyXML &doc, bool loadDefaults /*=false */)


### PR DESCRIPTION
With the complete map copy was before the values from hidden
parts removed.