### PR TITLE
insert new addons into installed table

### DIFF
--- a/xbmc/addons/AddonDatabase.cpp
+++ b/xbmc/addons/AddonDatabase.cpp
@@ -1076,6 +1076,16 @@ bool CAddonDatabase::AddPackage(const std::string& addonID,
   return ExecuteQuery(sql);
 }
 
+bool CAddonDatabase::AddInstalled(const std::string& addonID, bool enabled)
+{
+  std::string now = CDateTime::GetCurrentDateTime().GetAsDBDateTime();
+
+  std::string sql = PrepareSQL("insert into installed(addonID, enabled, installDate)"
+    "values('%s', '%d', '%s')",
+    addonID.c_str(), enabled ? 1 : 0, now.c_str());
+  return ExecuteQuery(sql);
+}
+
 bool CAddonDatabase::GetPackageHash(const std::string& addonID,
                                     const std::string& packageFileName,
                                     std::string&       hash)

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -115,6 +115,15 @@ public:
   bool AddPackage(const std::string& addonID,
                   const std::string& packageFileName,
                   const std::string& hash);
+
+  /*! \brief Store an addon in installed table
+  \param  addonID         id of the addon we're adding a package for
+  \param  enable          initial enable state of the addon
+  \return Whether or not the info successfully made it into the DB.
+  \sa SyncInstalled
+  */
+  bool AddInstalled(const std::string& addonID, bool enabled);
+
   /*! \brief Query the MD5 checksum of the given given addon's given package
       \param  addonID         id of the addon we're who's package we're querying
       \param  packageFileName filename of the package

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -540,6 +540,7 @@ bool CAddonMgr::AddNewInstalledAddon(AddonInfoPtr& addonInfo)
   AddonInfoPtr installedAddonInfo = std::make_shared<CAddonInfo>("special://home/addons/" + addonInfo->ID());
   if (installedAddonInfo->IsUsable())
   {
+    m_database.AddInstalled(addonInfo->ID(), true);
     m_installedAddons[addonInfo->ID()] = installedAddonInfo;
     if (EnableAddon(installedAddonInfo->ID()))
       return true;


### PR DESCRIPTION
Currently new installed addons disappear after kodi restart.
Reason is, that they have not been inserted into the installed table from addon27.db.

This PR fixes this issue