### PR TITLE
Videocodec / ready to merge :-)

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -286,6 +286,11 @@ bool CAddonInstaller::InstallFromZip(const std::string &path)
     if (CAddonMgr::LoadAddonDescription(addon, items[0]->GetPath()))
     {
       addon->SetPath(path);
+      // Delete the package file to force the selected one.
+      std::string package = URIUtils::AddFileToFolder("special://home/addons/packages/", URIUtils::GetFileName(path));
+      if (!URIUtils::CompareWithoutSlashAtEnd(package,path))
+        CFile::Delete(package);
+
       return DoInstall(addon, RepositoryPtr());
     }
   }

--- a/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
+++ b/xbmc/cores/VideoPlayer/DVDCodecs/DVDFactoryCodec.cpp
@@ -81,6 +81,7 @@ CDVDVideoCodec* CDVDFactoryCodec::CreateVideoCodec(CDVDStreamInfo &hint, CProces
         return pCodec.release();
       }
     }
+    return false;
   }
 
   // platform specifig video decoders

--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -1114,7 +1114,7 @@ void URIUtils::RemoveSlashAtEnd(std::string& strFolder)
 
 bool URIUtils::CompareWithoutSlashAtEnd(const std::string& strPath1, const std::string& strPath2)
 {
-  std::string strc1 = strPath1, strc2 = strPath2;
+  std::string strc1 = CSpecialProtocol::TranslatePath(strPath1), strc2 = CSpecialProtocol::TranslatePath(strPath2);
   RemoveSlashAtEnd(strc1);
   RemoveSlashAtEnd(strc2);
   return StringUtils::EqualsNoCase(strc1, strc2);


### PR DESCRIPTION
1.) Dont try to use other decoder if external decoder is given but fails.
2.) Remove  addon's zip file from packages cache folder in case InstalFromZip is called.

Currently the file from packages cache is choosen with higher priority than the zip file selected.
This makes it really hard during a developing process.