### PR TITLE
ignore content_type option in plugin::history

### DIFF
--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -1250,7 +1250,7 @@ void CGUIMediaWindow::SetHistoryForPath(const std::string& strDirectory)
   if (!strDirectory.empty())
   {
     // Build the directory history for default path
-    std::string strPath, strParentPath;
+    std::string strPath, strParentPath, strOptions;
     strPath = strDirectory;
     URIUtils::RemoveSlashAtEnd(strPath);
 
@@ -1259,9 +1259,30 @@ void CGUIMediaWindow::SetHistoryForPath(const std::string& strDirectory)
 
     m_history.ClearPathHistory();
 
+    if (URIUtils::IsPlugin(strPath))
+    {
+      CURL url(strPath);
+      std::map<std::string, std::string> options;
+      url.GetOptions(options);
+      if (options.size() == 1 && options.begin()->first == "content_type")
+      {
+        strOptions = url.GetOptions();
+        url.SetOptions("");
+        strPath = url.Get();
+      }
+    }
+
     bool originalPath = true;
     while (URIUtils::GetParentPath(strPath, strParentPath))
     {
+      if (!strOptions.empty())
+      {
+        CURL url(strPath);
+        url.SetOptions(strOptions);
+        strPath = url.Get();
+        strOptions.clear();
+      }
+
       for (int i = 0; i < (int)items.Size(); ++i)
       {
         CFileItemPtr pItem = items[i];


### PR DESCRIPTION
The addon rework changed the initial path logic that &content_type=[type] is always added, regardless if there is only one provides defined in addon.xml.

This leads to double entry in history and needs 2 [back] clicks to leave the addon.

This PR skips the additional history entry and behaviour is now again as before.
Benefit: this fixes also the bug in master if more than 1 provides is defined.