### PR TITLE
don't go back to previous window when playing playlist

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3440,7 +3440,6 @@ PlayBackRet CApplication::PlayFile(CFileItem item, const std::string& player, bo
     else
     {
       if (g_windowManager.GetActiveWindow() == WINDOW_VISUALISATION ||
-          g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_VIDEO ||
           g_windowManager.GetActiveWindow() == WINDOW_FULLSCREEN_GAME)
         g_windowManager.PreviousWindow();
     }


### PR DESCRIPTION
When playing a playlist with several files and a vidoe finishes,
KODI switches to the next video in playlist. That action causes
fulscreen window being deinited and previous one displayed instead
(which breaks playlist playback in different ways depending on
what previous window were displayed before playlist playback has
been started).

Fixes regression introduced by:
  commit acd30c1bf3 Implement FullscreenGame window
  Author: Garrett Brown <themagnificentmrb@gmail.com>