### PR TITLE
[linux] Fixes for linux builds

### DIFF
--- a/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
+++ b/xbmc/cores/ExternalPlayer/ExternalPlayer.cpp
@@ -242,9 +242,14 @@ void CExternalPlayer::Process()
 #endif
     strFName = m_filename;
 
+#if defined(TARGET_POSIX)
+  strFArgs.append(m_filename);
+  strFArgs.append(" ");
+#else
   strFArgs.append("\"");
   strFArgs.append(m_filename);
   strFArgs.append("\" ");
+#endif
   strFArgs.append(m_args);
 
   int nReplaced = StringUtils::Replace(strFArgs, "{0}", mainFile);

--- a/xbmc/windowing/X11/WinSystemX11GLContext.cpp
+++ b/xbmc/windowing/X11/WinSystemX11GLContext.cpp
@@ -199,6 +199,12 @@ XVisualInfo* CWinSystemX11GLContext::GetVisual()
 
   visual = XGetVisualInfo(m_dpy, vMask, &vTemplate, &count);
 
+  if (!visual)
+  {
+    vTemplate.depth = 30;
+    visual = XGetVisualInfo(m_dpy, vMask, &vTemplate, &count);
+  }
+
   return visual;
 }
 


### PR DESCRIPTION
These "fixes" are required for my setup and may be needed by other users.
First one removes the double quotes enclosing the executable name in ExternalPlayer, which breaks it on my Ubuntu 17.10 system. These double-quotes are only required around the filename arg.
Second one allows 10bits/channel visual detection as a fallback if 8bits/channel is not found (and prevents the associated kodi crash), which may be needed eventually when higher bit-depths will become better supported on linux.