### PR TITLE
Revert "CSetCurrentItemJob: CFileItem instances need to by copied bef…

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -3906,7 +3906,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
         CServiceBroker::GetPlaylistPlayer().SetCurrentSong(m_nextPlaylistItem);
         m_itemCurrentFile.reset(new CFileItem(*item));
       }
-      g_infoManager.SetCurrentItem(*m_itemCurrentFile);
+      g_infoManager.SetCurrentItem(m_itemCurrentFile);
       g_partyModeManager.OnSongChange(true);
 
       CVariant param;

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -1988,7 +1988,7 @@ bool CApplication::OnAction(const CAction &action)
     {
       m_itemCurrentFile->GetMusicInfoTag()->SetUserrating(userrating);
       // Mirror changes to GUI item
-      g_infoManager.SetCurrentItem(*m_itemCurrentFile);
+      g_infoManager.SetCurrentItem(m_itemCurrentFile);
       
       // Asynchronously update song userrating in music library
       MUSIC_UTILS::UpdateSongRatingJob(m_itemCurrentFile, userrating);
@@ -2017,7 +2017,7 @@ bool CApplication::OnAction(const CAction &action)
     if (needsUpdate)
     {
       // Mirror changes to current GUI item
-      g_infoManager.SetCurrentItem(*m_itemCurrentFile);
+      g_infoManager.SetCurrentItem(m_itemCurrentFile);
 
       // Asynchronously update song userrating in music library
       MUSIC_UTILS::UpdateSongRatingJob(m_itemCurrentFile, m_itemCurrentFile->GetMusicInfoTag()->GetUserrating());
@@ -2046,7 +2046,7 @@ bool CApplication::OnAction(const CAction &action)
     if (needsUpdate)
     {
       // Mirror changes to GUI item
-      g_infoManager.SetCurrentItem(*m_itemCurrentFile);
+      g_infoManager.SetCurrentItem(m_itemCurrentFile);
 
       CVideoDatabase db;
       if (db.Open())
@@ -3875,7 +3875,7 @@ bool CApplication::OnMessage(CGUIMessage& message)
         if (m_itemCurrentFile->IsSamePath(item.get()))
         {
           m_itemCurrentFile->UpdateInfo(*item);
-          g_infoManager.SetCurrentItem(*m_itemCurrentFile);
+          g_infoManager.SetCurrentItem(m_itemCurrentFile);
         }
       }
     }

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -130,8 +130,7 @@ class CSetCurrentItemJob : public CJob
 {
   CFileItemPtr m_itemCurrentFile;
 public:
-  explicit CSetCurrentItemJob(const CFileItem& item) : m_itemCurrentFile(std::make_shared<CFileItem>(item)) { }
-
+  explicit CSetCurrentItemJob(const CFileItemPtr& item) : m_itemCurrentFile(item) { }
   ~CSetCurrentItemJob(void) override = default;
 
   bool DoWork(void) override
@@ -9055,7 +9054,7 @@ void CGUIInfoManager::ResetCurrentItem()
   m_currentMovieDuration = "";
 }
 
-void CGUIInfoManager::SetCurrentItem(const CFileItem &item)
+void CGUIInfoManager::SetCurrentItem(const CFileItemPtr item)
 {
   CSetCurrentItemJob *job = new CSetCurrentItemJob(item);
   CJobManager::GetInstance().AddJob(job, NULL);
@@ -10919,12 +10918,13 @@ void CGUIInfoManager::OnApplicationMessage(KODI::MESSAGING::ThreadMessage* pMsg)
     if (!item)
       return;
 
+    CFileItemPtr itemptr(item);
     if (pMsg->param1 == 1 && item->HasMusicInfoTag()) // only grab music tag
       SetCurrentSongTag(*item->GetMusicInfoTag());
     else if (pMsg->param1 == 2 && item->HasVideoInfoTag()) // only grab video tag
       SetCurrentVideoTag(*item->GetVideoInfoTag());
     else
-      SetCurrentItem(*item);
+      SetCurrentItem(itemptr);
   }
   break;
 

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -151,7 +151,7 @@ public:
   /*! \brief Set currently playing file item
    \param blocking whether to run in current thread (true) or background thread (false)
    */
-  void SetCurrentItem(const CFileItem &item);
+  void SetCurrentItem(const CFileItemPtr item);
   void ResetCurrentItem();
   // Current song stuff
   /// \brief Retrieves tag info (if necessary) and fills in our current song path.

--- a/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
+++ b/xbmc/cores/VideoPlayer/VideoPlayerRadioRDS.cpp
@@ -629,7 +629,8 @@ void CDVDRadioRDSData::ResetRDSCache()
   m_currentInfoTag = CPVRRadioRDSInfoTag::CreateDefaultTag();
   m_currentChannel = g_application.CurrentFileItem().GetPVRChannelInfoTag();
   g_application.CurrentFileItem().SetPVRRadioRDSInfoTag(m_currentInfoTag);
-  g_infoManager.SetCurrentItem(g_application.CurrentFileItem());
+  CFileItemPtr itemptr(new CFileItem(g_application.CurrentFileItem()));
+  g_infoManager.SetCurrentItem(itemptr);
 
   // send a message to all windows to tell them to update the radiotext
   CGUIMessage msg(GUI_MSG_NOTIFY_ALL, 0, 0, GUI_MSG_UPDATE_RADIOTEXT);
@@ -856,7 +857,8 @@ void CDVDRadioRDSData::ProcessUECP(const unsigned char *data, unsigned int len)
 
           if (m_currentFileUpdate && !m_bStop)
           {
-            g_infoManager.SetCurrentItem(g_application.CurrentFileItem());
+            CFileItemPtr itemptr(new CFileItem(g_application.CurrentFileItem()));
+            g_infoManager.SetCurrentItem(itemptr);
             m_currentFileUpdate = false;
           }
         }

--- a/xbmc/pvr/PVRGUIChannelNavigator.cpp
+++ b/xbmc/pvr/PVRGUIChannelNavigator.cpp
@@ -83,7 +83,7 @@ namespace PVR
 
   void CPVRGUIChannelNavigator::SelectChannel(const CPVRChannelPtr channel, ChannelSwitchMode eSwitchMode)
   {
-    g_infoManager.SetCurrentItem(CFileItem(channel));
+    g_infoManager.SetCurrentItem(CFileItemPtr(new CFileItem(channel)));
 
     CSingleLock lock(m_critSection);
     m_currentChannel = channel;
@@ -186,7 +186,7 @@ namespace PVR
     }
 
     if (item)
-      g_infoManager.SetCurrentItem(*item);
+      g_infoManager.SetCurrentItem(item);
   }
 
   void CPVRGUIChannelNavigator::ToggleInfo()
@@ -212,7 +212,7 @@ namespace PVR
     }
 
     if (item)
-      g_infoManager.SetCurrentItem(*item);
+      g_infoManager.SetCurrentItem(item);
 
     ShowInfo(false);
   }


### PR DESCRIPTION
…ore they can be used safely in another thread (here, the job worker thread)."

Current playlist is broken since commit 87ce7cccb31a5df4e946a8b9fc878a2e985d6625
Steps to reproduce start playing videos in directory (not in database in my case)
using builtin 'PlayMedia(/path/to/dir,isdir)' and then trigger action 'Playlist'
(both mapped to remote keys but it's the same with eventclient).
As result of the last action empty playlist will be shown.

Reverting offending commit brings current playlist back.

Signed-off-by: Igor Mammedov <niallain@gmail.com>
---
PS:
I've been testing and carrying this patch in my tree since October 2017,
so far nothing seems be broken so publishing it for others to use
until original patch is fixed.